### PR TITLE
Fix the help output for the clean_text binary.

### DIFF
--- a/examples/clean_text.cc
+++ b/examples/clean_text.cc
@@ -46,7 +46,7 @@ static std::string cleantext(GumboNode* node) {
 
 int main(int argc, char** argv) {
   if (argc != 2) {
-    std::cout << "Usage: get_title <html filename>.\n";
+    std::cout << "Usage: clean_text <html filename>\n";
     exit(EXIT_FAILURE);
   }
   const char* filename = argv[1];


### PR DESCRIPTION
Fixes the issue: https://github.com/google/gumbo-parser/issues/8

Signed-off-by: Sankar P sankar.curiosity@gmail.com
