### PR TITLE
Add Travis CI to give quicker feedback on pull requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c++
+
+compiler:
+  - gcc
+  - clang
+
+install:
+  - wget 'https://googletest.googlecode.com/files/gtest-1.6.0.zip'
+  - unzip gtest-1.6.0.zip
+  - ln -s gtest-1.6.0 gtest
+  - sudo pip install html5lib
+
+script:
+  - ./configure && make && make check
+  - sudo make install
+  - LD_LIBRARY_PATH=/usr/local/lib python python/gumbo/html5lib_adapter_test.py


### PR DESCRIPTION
There are a few things I'm not entirely convinced about in this, most notably having to use LD_LIBRARY_PATH for it to find the library. However, having CI giving feedback on pull requests is typically a win in my experience, as it makes people realize they've broken things when they otherwise wouldn't have!

See http://about.travis-ci.org/docs/user/getting-started/ for more setup on Travis CI needed before merging this. (Ideally this merge would be the first thing after enabling it.)
