### PR TITLE
Fix usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Basic Usage
 Within your program, you need to include "gumbo.h" and then issue a call to
 `gumbo_parse`:
 
-```C++
+```C
 #include "gumbo.h"
 
-int main(int argc, char** argv) {
-  GumboOutput* output = gumbo_parse(argv[1]);
+int main() {
+  GumboOutput* output = gumbo_parse("<h1>Hello, World!</h1>");
   // Do stuff with output->root
   gumbo_destroy_output(&kGumboDefaultOptions, output);
 }


### PR DESCRIPTION
It may be a little pedantic, but this fixes a segfault in the usage example when `argc < 2`. I think it also helps to clarify, at a glance, that `gumbo_parse` takes a string of text rather than a filename.
