### PR TITLE
Fix invalid return expressions in functions returning void

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -43,7 +43,7 @@ static void* malloc_wrapper(void* unused, size_t size) {
 }
 
 static void free_wrapper(void* unused, void* ptr) {
-  return free(ptr);
+  free(ptr);
 }
 
 const GumboOptions kGumboDefaultOptions = {

--- a/src/util.c
+++ b/src/util.c
@@ -36,7 +36,7 @@ void* gumbo_parser_allocate(GumboParser* parser, size_t num_bytes) {
 }
 
 void gumbo_parser_deallocate(GumboParser* parser, void* ptr) {
-  return parser->_options->deallocator(parser->_options->userdata, ptr);
+  parser->_options->deallocator(parser->_options->userdata, ptr);
 }
 
 char* gumbo_copy_stringz(GumboParser* parser, const char* str) {


### PR DESCRIPTION
Building Gumbo with GCC 4.8.1 using the flags `-std=c99 -Wpedantic` produces the following warnings:

```
src/parser.c:46:3: warning: ISO C forbids 'return' with expression, in function returning void [-Wpedantic]
src/util.c:39:3: warning: ISO C forbids 'return' with expression, in function returning void [-Wpedantic]
```

Building with tcc causes the fatal error `Cannot assign void value` for the same 2 lines.

This patch makes the warnings/errors go away.
