### PR TITLE
Next/prev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ config.log
 config.status
 config.sub
 configure
+core
 depcomp
+gtest/
 gumbo.pc
 gumbo_test
 gumbo_test.log

--- a/python/gumbo/gumboc.py
+++ b/python/gumbo/gumboc.py
@@ -482,6 +482,8 @@ Node._fields_ = [
     ('type', NodeType),
     # Set the type to Node later to avoid a circular dependency.
     ('parent', _Ptr(Node)),
+    ('next', _Ptr(Node)),
+    ('prev', _Ptr(Node)),
     ('index_within_parent', ctypes.c_size_t),
     # TODO(jdtang): Make a real list of enum constants for this.
     ('parse_flags', _bitvector),

--- a/python/gumbo/gumboc_test.py
+++ b/python/gumbo/gumboc_test.py
@@ -60,6 +60,14 @@ class CtypesTest(unittest.TestCase):
       self.assertEquals(gumboc.NodeType.TEXT, text_node.type)
       self.assertEquals('Test', text_node.text)
 
+      self.assertEquals(gumboc.Tag.HEAD, root.next.contents.tag)
+      self.assertEquals(gumboc.Tag.BODY, head.next.contents.tag)
+      self.assertEquals(gumboc.NodeType.TEXT, body.next.contents.type)
+      self.assertEquals(gumboc.Tag.BODY, text_node.prev.contents.tag)
+      self.assertEquals(gumboc.Tag.HEAD, body.prev.contents.tag)
+      self.assertEquals(gumboc.Tag.HTML, head.prev.contents.tag)
+      self.assertEquals(gumboc.NodeType.DOCUMENT, root.prev.contents.type)
+
   def testBufferThatGoesAway(self):
     for i in range(10):
       source = StringIO.StringIO('<foo bar=quux>1<p>2</foo>')

--- a/python/gumbo/soup_adapter.py
+++ b/python/gumbo/soup_adapter.py
@@ -22,6 +22,7 @@ can then manipulate like a normal BeautifulSoup parse tree.
 __author__ = 'jdtang@google.com (Jonathan Tang)'
 
 import BeautifulSoup
+import ctypes
 
 import gumboc
 
@@ -40,6 +41,16 @@ def _add_source_info(obj, original_text, start_pos, end_pos):
   obj.end_offset = end_pos.offset
 
 
+def _add_document(element):
+  # Currently ignored, since there's no real place for this in the BeautifulSoup
+  # API.
+  pass
+
+
+def _add_text(cls):
+  return lambda element: cls(_utf8(element.text))
+
+
 def _convert_attrs(attrs):
   # TODO(jdtang): Ideally attributes would pass along their positions as well,
   # but I can't extend the built in str objects with new attributes.  Maybe work
@@ -47,48 +58,66 @@ def _convert_attrs(attrs):
   return [(_utf8(attr.name), _utf8(attr.value)) for attr in attrs]
 
 
-def _add_document(soup, element):
-  # Currently ignored, since there's no real place for this in the BeautifulSoup
-  # API.
-  pass
+class _Converter(object):
+  def __init__(self, text, **kwargs):
+    # We need to record the addresses of GumboNodes as we add them and correlate
+    # them with the BeautifulSoup objects that they become.  This lets us
+    # correctly wire up the next/previous pointers so that they point to
+    # BeautifulSoup objects instead of ctypes ones.
+    self._node_map = {}
+    self._HANDLERS = [
+        _add_document,
+        self._add_element,
+        _add_text(BeautifulSoup.NavigableString),
+        _add_text(BeautifulSoup.CData),
+        _add_text(BeautifulSoup.Comment),
+        _add_text(BeautifulSoup.NavigableString),
+        ]
+    self.soup = BeautifulSoup.BeautifulSoup()
+    with gumboc.parse(text, **kwargs) as output:
+      self.soup.append(self._add_node(output.contents.root.contents))
+    
+    self._fix_next_prev_pointers(self.soup)
 
+  def _add_element(self, element):
+    tag = BeautifulSoup.Tag(
+        self.soup, _utf8(element.tag_name), _convert_attrs(element.attributes))
+    for child in element.children:
+      tag.append(self._add_node(child))
+    _add_source_info(
+        tag, element.original_tag, element.start_pos, element.end_pos)
+    tag.original_end_tag = str(element.original_end_tag)
+    return tag
 
-def _add_element(soup, element):
-  # TODO(jdtang): Expose next/previous in gumbo so they can be passed along to
-  # BeautifulSoup.
-  tag = BeautifulSoup.Tag(
-      soup, _utf8(element.tag_name), _convert_attrs(element.attributes))
-  for child in element.children:
-    tag.append(_add_node(soup, child))
-  _add_source_info(
-      tag, element.original_tag, element.start_pos, element.end_pos)
-  tag.original_end_tag = str(element.original_end_tag)
-  return tag
+  def _add_node(self, node):
+    result = self._HANDLERS[node.type.value](node.contents)
 
+    try:
+      result.next_addr = ctypes.addressof(node.next.contents)
+    except ValueError:
+      # Null pointer.
+      result.next_addr = 0
 
-def _add_text(cls):
-  def add_text_internal(soup, element):
-    text = cls(_utf8(element.text))
-    return text
-  return add_text_internal
+    try:
+      result.prev_addr = ctypes.addressof(node.prev.contents)
+    except ValueError:
+      # Null pointer.
+      result.prev_addr = 0
 
+    self._node_map[ctypes.addressof(node.contents)] = result
+    return result
 
-_HANDLERS = [
-    _add_document,
-    _add_element,
-    _add_text(BeautifulSoup.NavigableString),
-    _add_text(BeautifulSoup.CData),
-    _add_text(BeautifulSoup.Comment),
-    _add_text(BeautifulSoup.NavigableString),
-    ]
-
-
-def _add_node(soup, node):
-  return _HANDLERS[node.type.value](soup, node.contents)
+  def _fix_next_prev_pointers(self, tag):
+    tag.next = self._node_map.get(tag.next_addr)
+    tag.prev = self._node_map.get(tag.prev_addr)
+    try:
+      for child in tag.children:
+        self._fix_next_prev_pointers(child)
+    except (AttributeError, TypeError):
+      # NavigableStrings
+      pass
 
 
 def parse(text, **kwargs):
-  with gumboc.parse(text, **kwargs) as output:
-    soup = BeautifulSoup.BeautifulSoup()
-    soup.append(_add_node(soup, output.contents.root.contents))
-    return soup
+  converter = _Converter(text, **kwargs)
+  return converter.soup

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -678,6 +678,19 @@ struct GumboInternalNode {
   /** Pointer back to parent node.  Not owned. */
   GumboNode* parent;
 
+  /**
+   * Pointer to next node in document order.  This is the next node by start tag
+   * position in the document, or by position of the tag that forces the parser
+   * to insert it for parser-inserted nodes.  It's necessary to maintain API
+   * compatibility with some other libraries, eg. BeautifulSoup.  Not owned.
+   */
+  GumboNode* next;
+
+  /**
+   * Pointer to previous node in document order.
+   */
+  GumboNode* prev;
+
   /** The index within the parent's children vector of this node. */
   size_t index_within_parent;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -3830,11 +3830,14 @@ GumboOutput* gumbo_parse_with_options(
     const GumboOptions* options, const char* buffer, size_t length) {
   GumboParser parser;
   parser._options = options;
-  gumbo_tokenizer_state_init(&parser, buffer, length);
   parser_state_init(&parser);
   // Must come after parser_state_init, since creating the document node must
   // reference parser_state->_current_node.
   output_init(&parser);
+  // And this must come after output_init, because initializing the tokenizer
+  // reads the first character and that may cause a UTF-8 decode error
+  // (inserting into output->errors) if that's invalid.
+  gumbo_tokenizer_state_init(&parser, buffer, length);
 
   GumboParserState* state = parser._parser_state;
   gumbo_debug("Parsing %.*s.\n", length, buffer);

--- a/src/util.c
+++ b/src/util.c
@@ -45,6 +45,8 @@ char* gumbo_copy_stringz(GumboParser* parser, const char* str) {
   return buffer;
 }
 
+#define GUMBO_DEBUG
+
 // Debug function to trace operation of the parser.  Pass --copts=-DGUMBO_DEBUG
 // to use.
 void gumbo_debug(const char* format, ...) {

--- a/src/util.c
+++ b/src/util.c
@@ -45,8 +45,6 @@ char* gumbo_copy_stringz(GumboParser* parser, const char* str) {
   return buffer;
 }
 
-#define GUMBO_DEBUG
-
 // Debug function to trace operation of the parser.  Pass --copts=-DGUMBO_DEBUG
 // to use.
 void gumbo_debug(const char* format, ...) {


### PR DESCRIPTION
Add next & prev fields to GumboNodes to traverse the tree in the order that nodes were added.  Also add them to the ctypes & BeautifulSoup bindings.

This was necessary to bring the BeautifulSoup adapter into compliance; turns out some of the lesser-used functions in the BS3 API rely on those fields having useful values.  It may be useful for other tools or language bindings as well.

As an API change, this should probably get a version number bump (0.10?  It's a little weird, not having reached 1.0 yet).  As a pure addition it shouldn't create any API compatibility problems, although it changes the ABI.  Comments?