### PR TITLE
Fix duplicate attributes in <isindex>

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2715,7 +2715,7 @@ static bool handle_in_body(GumboParser* parser, GumboToken* token) {
     GumboVector* token_attrs = &token->v.start_tag.attributes;
     GumboAttribute* prompt_attr = gumbo_get_attribute(token_attrs, "prompt");
     GumboAttribute* action_attr = gumbo_get_attribute(token_attrs, "action");
-    GumboAttribute* name_attr = gumbo_get_attribute(token_attrs, "isindex");
+    GumboAttribute* name_attr = gumbo_get_attribute(token_attrs, "name");
 
     GumboNode* form = insert_element_of_tag_type(
         parser, GUMBO_TAG_FORM, GUMBO_INSERTION_FROM_ISINDEX);

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -1261,10 +1261,9 @@ TEST_F(GumboParserTest, IsIndexDuplicateAttribute) {
   ASSERT_EQ(0, GetChildCount(input));
   ASSERT_EQ(1, GetAttributeCount(input));
 
-  GumboAttribute* name = GetAttribute(input, 1);
+  GumboAttribute* name = GetAttribute(input, 0);
   EXPECT_STREQ("name", name->name);
   EXPECT_STREQ("isindex", name->value);
-
 }
 
 TEST_F(GumboParserTest, NestedRawtextTags) {


### PR DESCRIPTION
Fixes #237.  The cause was a typo when searching for the 'name' attribute of the <isindex> tag.  @craigbarnes, would you like to review?
