### PR TITLE
The get_title example should handle whitespace-only titles

### DIFF
--- a/examples/get_title.c
+++ b/examples/get_title.c
@@ -61,7 +61,7 @@ static const char* find_title(const GumboNode* root) {
         return "<empty title>";
       }
       GumboNode* title_text = child->v.element.children.data[0];
-      assert(title_text->type == GUMBO_NODE_TEXT);
+      assert(title_text->type == GUMBO_NODE_TEXT || title_text->type == GUMBO_NODE_WHITESPACE);
       return title_text->v.text.text;
     }
   }


### PR DESCRIPTION
Previously, we asserted that the title's first child was a text node; this does not hold if the title consists solely of whitespace. As a result, it would for example assert for `<title> </title>`.
