### PR TITLE
Add MacOS X Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ compiler:
   - gcc
   - clang
 
+os:
+  - linux
+  - osx
+
 install:
   - wget 'https://googletest.googlecode.com/files/gtest-1.6.0.zip'
   - unzip gtest-1.6.0.zip


### PR DESCRIPTION
Just had this enabled via Travis CI support e-mail, trying it out.
