### PR TITLE
Improve serialize.cc example to handle unknown tags properly, add prettyprint.cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@
 *.swo
 *.swn
 
+# diff leftovers
+*.orig
+
+#Emacs leftovers
+*~
+#*#
+
 # Other build artifacts
 /Debug
 /visualc/Debug

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ gumbo_test_DEPENDENCIES += check-local
 gumbo_test_LDADD += gtest/lib/libgtest.la gtest/lib/libgtest_main.la
 endif
 
-noinst_PROGRAMS = clean_text find_links get_title positions_of_class benchmark serialize
+noinst_PROGRAMS = clean_text find_links get_title positions_of_class benchmark serialize prettyprint
 LDADD = libgumbo.la
 AM_CPPFLAGS = -I"$(srcdir)/src"
 
@@ -107,3 +107,4 @@ get_title_SOURCES = examples/get_title.c
 positions_of_class_SOURCES = examples/positions_of_class.cc
 benchmark_SOURCES = benchmarks/benchmark.cc
 serialize_SOURCES = examples/serialize.cc
+prettyprint_SOURCES = examples/prettyprint.cc

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ gumbo_test_DEPENDENCIES += check-local
 gumbo_test_LDADD += gtest/lib/libgtest.la gtest/lib/libgtest_main.la
 endif
 
-noinst_PROGRAMS = clean_text find_links get_title positions_of_class benchmark serialize prettyprint
+noinst_PROGRAMS = clean_text find_links get_title positions_of_class benchmark serialize prettyprint well_formed
 LDADD = libgumbo.la
 AM_CPPFLAGS = -I"$(srcdir)/src"
 
@@ -108,3 +108,4 @@ positions_of_class_SOURCES = examples/positions_of_class.cc
 benchmark_SOURCES = benchmarks/benchmark.cc
 serialize_SOURCES = examples/serialize.cc
 prettyprint_SOURCES = examples/prettyprint.cc
+well_formed_SOURCES = examples/well_formed.cc

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gumbo - A pure-C HTML5 parser.
 Modified version of google's upstream gumbo-parser
 Includes:
  - support for xhtml parsing (specifically injects close tag tokens for non-void but self-closed tags)
- - xhtml parsing support includes fix for horrible parsing of rcdata tags like <title/> in <head>
+ - xhtml parsing support includes fix for horrible parsing of rcdata tags like &lt;title/&gt; in <head>
  - added improved serialize example in C++ which includes support for unknown tags
  - added prettyprint example in C++
  - improved find_links to return all outside references that might need to be updated

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 Gumbo - A pure-C HTML5 parser.
 ============
 
+Modified version of google's upstream gumbo-parser
+Includes:
+ - support for xhtml parsing (specifically injects close tag tokens for non-void but self-closed tags)
+ - xhtml parsing support includes fix for horrible parsing of rcdata tags like <title/> in <head>
+ - added improved serialize example in C++ which includes support for unknown tags
+ - added prettyprint example in C++
+ - improved find_links to return all outside references that might need to be updated
+ - added well_formed checking example in C++ 
+
+To Do:
+ - more xhtml5 support changes coming including opf namespace for epub:type and additional tags epub:switch et.al.
+ - create editor to allow gumbo tree to be modified after creation to create a more complete dom replacement
+
+All modifications available under the same license as the original gumbo-parser
+
 [![Build Status](https://travis-ci.org/google/gumbo-parser.svg?branch=master)](https://travis-ci.org/google/gumbo-parser)
 
 Gumbo is an implementation of the [HTML5 parsing algorithm][] implemented

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gumbo - A pure-C HTML5 parser.
 Modified version of google's upstream gumbo-parser
 Includes:
  - support for xhtml parsing (specifically injects close tag tokens for non-void but self-closed tags)
- - xhtml parsing support includes fix for horrible parsing of rcdata tags like &lt;title/&gt; in <head>
+ - xhtml parsing support includes fix for horrible parsing of rcdata tags like &lt;title/&gt; in &lt;head&gt;
  - added improved serialize example in C++ which includes support for unknown tags
  - added prettyprint example in C++
  - improved find_links to return all outside references that might need to be updated

--- a/examples/well_formed.cc
+++ b/examples/well_formed.cc
@@ -1,0 +1,75 @@
+// Copyright 2015 Kevin B. Hendricks, Stratford, Ontario,  All Rights Reserved.
+// loosely based on a greatly simplified version of BeautifulSoup4 decode() routine
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Kevin Hendricks
+//
+
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
+#include <string>
+
+#include "gumbo.h"
+#include "error.h"
+#include "parser.h"
+#include "string_buffer.h"
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+      std::cout << "well_formed <html filename>\n";
+      exit(EXIT_FAILURE);
+  }
+  const char* filename = argv[1];
+
+  std::ifstream in(filename, std::ios::in | std::ios::binary);
+  if (!in) {
+    std::cout << "File " << filename << " not found!\n";
+    exit(EXIT_FAILURE);
+  }
+
+  std::string contents;
+  in.seekg(0, std::ios::end);
+  contents.resize(in.tellg());
+  in.seekg(0, std::ios::beg);
+  in.read(&contents[0], contents.size());
+  in.close();
+ 
+  fprintf(stdout, "%s", contents.c_str());
+
+  GumboOptions myoptions = kGumboDefaultOptions;
+  myoptions.use_xhtml_rules = true;
+  // leave this as false to prevent pre-mature stopping when no error exists
+  myoptions.stop_on_first_error = false;
+  
+  GumboOutput* output = gumbo_parse_with_options(&myoptions, contents.data(), contents.length());
+
+  GumboParser parser;
+  parser._options = &myoptions; 
+  const GumboVector* errors  = &output->errors;
+  for (int i=0; i< errors->length; ++i) {
+    GumboError* er = static_cast<GumboError*>(errors->data[i]);
+    unsigned int linenum = er->position.line;
+    unsigned int colnum = er->position.column;
+    unsigned int typenum = er->type;
+    GumboStringBuffer text;
+    gumbo_string_buffer_init(&parser, &text);
+    gumbo_error_to_string(&parser, er, &text);
+    std::string errmsg(text.data, text.length);
+    fprintf(stdout, "line: %d col: %d type %d %s\n", linenum, colnum, typenum, errmsg.c_str());
+    gumbo_string_buffer_destroy(&parser, &text);
+    gumbo_print_caret_diagnostic(&parser, er, contents.c_str());
+  }
+  gumbo_destroy_output(&myoptions, output);
+}

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -737,6 +737,12 @@ typedef struct GumboInternalOptions {
   int tab_stop;
 
   /**
+   * Whether to use xhtml parsing rules for self-closing non-void tags
+   * Default: false.
+   */
+  bool use_xhtml_rules;
+
+  /**
    * Whether or not to stop parsing when the first error is encountered.
    * Default: false.
    */


### PR DESCRIPTION
Just in case you are at all interested:
  
I improved on my simple serialize example  "serialize.cc" to handle unknown tags with empty names, and clean up a few other minor nits to make it more robust and to make as minimal a change in whitespace as possible so that the serialized output looks as close to the input (with gumbo's fixes!) as possible.

I also created a prettyprint.cc example that allows the user to set the indent amount used to "pretty print" the output to clean up any whitespace issue if so desired.

Thanks again for creating such a robust parser!  We will be including the gumbo-parser as a key part of our effort to redesign the Sigil ebook editor project (hosted here at github) to support both epub2 and epub3 editing over the next year.

