### PR TITLE
Match elements on qualified names, not just local names

### DIFF
--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -1707,4 +1707,88 @@ TEST_F(GumboParserTest, DoubleBody) {
   EXPECT_STREQ("Text", text->v.text.text);
 }
 
+TEST_F(GumboParserTest, ThInMathMl) {
+  Parse("<math><th><mI><table></table><tr></table><div><tr>0");
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(1, GetChildCount(body));
+
+  GumboNode* math = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, math->type);
+  EXPECT_EQ(GUMBO_TAG_MATH, math->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_MATHML, math->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(math));
+
+  GumboNode* th = GetChild(math, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, th->type);
+  EXPECT_EQ(GUMBO_TAG_TH, th->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_MATHML, th->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(th));
+
+  GumboNode* mi = GetChild(th, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, mi->type);
+  EXPECT_EQ(GUMBO_TAG_MI, mi->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_MATHML, mi->v.element.tag_namespace);
+  ASSERT_EQ(2, GetChildCount(mi));
+
+  GumboNode* table = GetChild(mi, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, table->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, table->v.element.tag_namespace);
+  ASSERT_EQ(0, GetChildCount(table));
+
+  GumboNode* div = GetChild(mi, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, div->type);
+  EXPECT_EQ(GUMBO_TAG_DIV, div->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, div->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(div));
+
+  GumboNode* text = GetChild(div, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_STREQ("0", text->v.text.text);
+}
+
+TEST_F(GumboParserTest, TdInMathml) {
+  Parse("<table><th><math><td></tr>");
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(1, GetChildCount(body));
+
+  GumboNode* table = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, table->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, table->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(table));
+
+  GumboNode* tbody = GetChild(table, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, tbody->type);
+  EXPECT_EQ(GUMBO_TAG_TBODY, tbody->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, tbody->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(tbody));
+
+  GumboNode* tr = GetChild(tbody, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, tr->type);
+  EXPECT_EQ(GUMBO_TAG_TR, tr->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, tr->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(tr));
+
+  GumboNode* th = GetChild(tr, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, th->type);
+  EXPECT_EQ(GUMBO_TAG_TH, th->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, th->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(th));
+
+  GumboNode* math = GetChild(th, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, math->type);
+  EXPECT_EQ(GUMBO_TAG_MATH, math->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_MATHML, math->v.element.tag_namespace);
+  ASSERT_EQ(1, GetChildCount(math));
+
+  GumboNode* td = GetChild(math, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, td->type);
+  EXPECT_EQ(GUMBO_TAG_TD, td->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_MATHML, td->v.element.tag_namespace);
+  ASSERT_EQ(0, GetChildCount(td));
+}
+
 }  // namespace


### PR DESCRIPTION
There are many places where the HTML spec says to look for an HTML element (i.e., an element in the HTML namespace) with a given tag, but where we were only looking at tag names and ignoring the namespace name.

Now we always use qualified names where required. This is implemented using a new `GumboQualName` type, which is just a bit field that combines a `GumboNamespaceEnum` with a `GumboTag`. A series of macros make it easy to construct and inspect these bit fields. It's currently represented by a `uintptr_t`. This is larger than necessary; only 9 bits are required. At first I attempted to use a `short` but the compiler didn't like that being used with varargs, so then I tried an `unsigned int` but the compiler didn't like casting that to a pointer, so here we are. I also tried `typedef enum { QNSIZE = SHORT_MAX } GumboQualName` to induce more compiler warnings when mistakenly passing a tag to a function that expects a qualified name. This worked nicely but generated warnings about missing cases in switch statements. I'm not sure what the best option is, though I am quite tempted by the extra warnings the enum provides.

Fixes #278 

/cc @gsnedders 