### PR TITLE
Eliminate extra reconstruction of formatting elements...

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2534,7 +2534,6 @@ static bool handle_in_body(GumboParser* parser, GumboToken* token) {
   } else if (tag_is(token, kEndTag, GUMBO_TAG_P)) {
     if (!has_an_element_in_button_scope(parser, GUMBO_TAG_P)) {
       parser_add_parse_error(parser, token);
-      reconstruct_active_formatting_elements(parser);
       insert_element_of_tag_type(
           parser, GUMBO_TAG_P, GUMBO_INSERTION_CONVERTED_FROM_END_TAG);
       state->_reprocess_current_token = true;

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -1565,6 +1565,17 @@ TEST_F(GumboParserTest, FormattingTagsInHeading) {
   EXPECT_STREQ("text", text3->v.text.text);
 }
 
+TEST_F(GumboParserTest, ExtraReconstruction) {
+  Parse("<span><b></span></p>");
+
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(2, GetChildCount(body));
+
+  EXPECT_EQ(GUMBO_TAG_SPAN, GetTag(GetChild(body, 0)));
+  EXPECT_EQ(GUMBO_TAG_P, GetTag(GetChild(body, 1)));
+}
+
 TEST_F(GumboParserTest, LinkifiedHeading) {
   Parse("<li><h3><a href=#foo>Text</a></h3><div>Summary</div>");
 


### PR DESCRIPTION
...when closing an unopened \<p> tag.  Fixes #234.