### PR TITLE
Fix assertion error for unterminated doctypes

### DIFF
--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -2568,7 +2568,8 @@ static StateResult handle_after_doctype_public_id_state(
       gumbo_tokenizer_set_state(parser, GUMBO_LEX_DATA);
       tokenizer->_reconsume_current_input = true;
       tokenizer->_doc_type_state.force_quirks = true;
-      return NEXT_CHAR;
+      emit_doctype(parser, output);
+      return RETURN_ERROR;
     default:
       tokenizer_add_parse_error(parser, GUMBO_ERR_DOCTYPE_INVALID);
       gumbo_tokenizer_set_state(parser, GUMBO_LEX_BOGUS_DOCTYPE);

--- a/tests/tokenizer.cc
+++ b/tests/tokenizer.cc
@@ -189,6 +189,20 @@ TEST_F(GumboTokenizerTest, DoctypeSystem) {
   EXPECT_STREQ("DTD_location", doc_type->system_identifier);
 }
 
+TEST_F(GumboTokenizerTest, DoctypeUnterminated) {
+  SetInput("<!DOCTYPE a PUBLIC''");
+  EXPECT_FALSE(gumbo_lex(&parser_, &token_));
+  ASSERT_EQ(GUMBO_TOKEN_DOCTYPE, token_.type);
+  EXPECT_EQ(0, token_.position.offset);
+
+  GumboTokenDocType* doc_type = &token_.v.doc_type;
+  EXPECT_TRUE(doc_type->force_quirks);
+  EXPECT_TRUE(doc_type->has_public_identifier);
+  EXPECT_FALSE(doc_type->has_system_identifier);
+  EXPECT_STREQ("a", doc_type->name);
+  EXPECT_STREQ("", doc_type->system_identifier);
+}
+
 TEST_F(GumboTokenizerTest, RawtextEnd) {
   SetInput("<title>x ignores <tag></title>");
   EXPECT_TRUE(gumbo_lex(&parser_, &token_));


### PR DESCRIPTION
Caused by them not emitting the token according to the spec.  Fixes #276.