### PR TITLE
Fix install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ script:
   - python python/gumbo/html5lib_adapter_test.py
   - python python/gumbo/soup_adapter_test.py
   - sudo make install
+  - g++ examples/clean_text.cc `pkg-config --cflags --libs gumbo`
   - sudo python setup.py sdist install
   - python -c 'import gumbo; gumbo.parse("Foo")'

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,7 @@ libgumbo_la_SOURCES = \
 				src/util.h \
 				src/vector.c \
 				src/vector.h
-include_HEADERS = src/gumbo.h
+include_HEADERS = src/gumbo.h src/tag_enum.h
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = gumbo.pc


### PR DESCRIPTION
Fixes #299, the tag_enum.h file not being installed with 'make install'.  Also adds a command to build one of the examples with pkg_config to travis.  @craigbarnes, this should fix your issue.