### PR TITLE
Html5lib fragment failures

### DIFF
--- a/python/gumbo/gumboc_test.py
+++ b/python/gumbo/gumboc_test.py
@@ -114,6 +114,20 @@ class CtypesTest(unittest.TestCase):
     self.assertEquals(gumboc.Tag.A, gumboc.Tag.A)
     self.assertEquals(hash(gumboc.Tag.A.value), hash(gumboc.Tag.A))
 
+  def testFragment(self):
+    with gumboc.parse(
+        '<div></div>',
+        container=gumboc.Tag.MS,
+        container_namespace=gumboc.Namespace.MATHML) as output:
+      root = output.contents.root.contents
+      self.assertEquals(1, len(root.children))
+      div = root.children[0]
+      self.assertEquals(gumboc.NodeType.ELEMENT, div.type)
+      self.assertEquals(gumboc.Tag.DIV, div.tag)
+      self.assertEquals(gumboc.Namespace.HTML, div.tag_namespace)
+
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/gumbo/gumboc_test.py
+++ b/python/gumbo/gumboc_test.py
@@ -117,8 +117,8 @@ class CtypesTest(unittest.TestCase):
   def testFragment(self):
     with gumboc.parse(
         '<div></div>',
-        container=gumboc.Tag.MS,
-        container_namespace=gumboc.Namespace.MATHML) as output:
+        container=gumboc.Tag.TITLE,
+        container_namespace=gumboc.Namespace.SVG) as output:
       root = output.contents.root.contents
       self.assertEquals(1, len(root.children))
       div = root.children[0]

--- a/src/parser.c
+++ b/src/parser.c
@@ -4001,36 +4001,39 @@ static void fragment_parser_init(
     fragment_namespace;
 
   // 4
-  switch (fragment_ctx) {
-    case GUMBO_TAG_TITLE:
-    case GUMBO_TAG_TEXTAREA:
-      gumbo_tokenizer_set_state(parser, GUMBO_LEX_RCDATA);
-      break;
+  if (fragment_namespace == GUMBO_NAMESPACE_HTML) {
+    // Non-HTML namespaces always start in the DATA state.
+    switch (fragment_ctx) {
+      case GUMBO_TAG_TITLE:
+      case GUMBO_TAG_TEXTAREA:
+        gumbo_tokenizer_set_state(parser, GUMBO_LEX_RCDATA);
+        break;
 
-    case GUMBO_TAG_STYLE:
-    case GUMBO_TAG_XMP:
-    case GUMBO_TAG_IFRAME:
-    case GUMBO_TAG_NOEMBED:
-    case GUMBO_TAG_NOFRAMES:
-      gumbo_tokenizer_set_state(parser, GUMBO_LEX_RAWTEXT);
-      break;
+      case GUMBO_TAG_STYLE:
+      case GUMBO_TAG_XMP:
+      case GUMBO_TAG_IFRAME:
+      case GUMBO_TAG_NOEMBED:
+      case GUMBO_TAG_NOFRAMES:
+        gumbo_tokenizer_set_state(parser, GUMBO_LEX_RAWTEXT);
+        break;
 
-    case GUMBO_TAG_SCRIPT:
-      gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT);
-      break;
+      case GUMBO_TAG_SCRIPT:
+        gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT);
+        break;
 
-    case GUMBO_TAG_NOSCRIPT:
-      /* scripting is disabled in Gumbo, so leave the tokenizer
-       * in the default data state */
-      break;
+      case GUMBO_TAG_NOSCRIPT:
+        /* scripting is disabled in Gumbo, so leave the tokenizer
+         * in the default data state */
+        break;
 
-    case GUMBO_TAG_PLAINTEXT:
-      gumbo_tokenizer_set_state(parser, GUMBO_LEX_PLAINTEXT);
-      break;
+      case GUMBO_TAG_PLAINTEXT:
+        gumbo_tokenizer_set_state(parser, GUMBO_LEX_PLAINTEXT);
+        break;
 
-    default:
-      /* default data state */
-      break;
+      default:
+        /* default data state */
+        break;
+    }
   }
 
   // 5. 6. 7.

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -1900,7 +1900,7 @@ TEST_F(GumboParserTest, TestTemplateInForeignContent) {
 }
 
 TEST_F(GumboParserTest, FragmentWithNamespace) {
-  ParseFragment("<div></div>", GUMBO_TAG_MS, GUMBO_NAMESPACE_MATHML);
+  ParseFragment("<div></div>", GUMBO_TAG_TITLE, GUMBO_NAMESPACE_SVG);
 
   EXPECT_EQ(1, GetChildCount(root_));
   GumboNode* html = GetChild(root_, 0);

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -1903,7 +1903,12 @@ TEST_F(GumboParserTest, FragmentWithNamespace) {
   ParseFragment("<div></div>", GUMBO_TAG_MS, GUMBO_NAMESPACE_MATHML);
 
   EXPECT_EQ(1, GetChildCount(root_));
-  GumboNode* div = GetChild(root_, 0);
+  GumboNode* html = GetChild(root_, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, html->type);
+  EXPECT_EQ(GUMBO_TAG_HTML, html->v.element.tag);
+  EXPECT_EQ(1, GetChildCount(html));
+
+  GumboNode* div = GetChild(html, 0);
   ASSERT_EQ(GUMBO_NODE_ELEMENT, div->type);
   EXPECT_EQ(GUMBO_TAG_DIV, div->v.element.tag);
   EXPECT_EQ(0, GetChildCount(div));

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -46,6 +46,17 @@ class GumboParserTest : public ::testing::Test {
     root_ = output_->document;
   }
 
+  virtual void ParseFragment(
+      const char* input, GumboTag context, GumboNamespaceEnum context_ns) {
+    if (output_) {
+      gumbo_destroy_output(&options_, output_);
+    }
+
+    output_ = gumbo_parse_fragment(
+        &options_, input, strlen(input), context, context_ns);
+    root_ = output_->document;
+  }
+
   virtual void Parse(const std::string& input) {
     // This overload is so we can test/demonstrate that computing offsets from
     // the .data() member of an STL string works properly.
@@ -1886,6 +1897,16 @@ TEST_F(GumboParserTest, TestTemplateInForeignContent) {
   EXPECT_EQ(GUMBO_TAG_TEMPLATE, svg_template->v.element.tag);
   EXPECT_EQ(GUMBO_NAMESPACE_SVG, svg_template->v.element.tag_namespace);
   EXPECT_EQ(0, GetChildCount(svg_template));
+}
+
+TEST_F(GumboParserTest, FragmentWithNamespace) {
+  ParseFragment("<div></div>", GUMBO_TAG_MS, GUMBO_NAMESPACE_MATHML);
+
+  EXPECT_EQ(1, GetChildCount(root_));
+  GumboNode* div = GetChild(root_, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, div->type);
+  EXPECT_EQ(GUMBO_TAG_DIV, div->v.element.tag);
+  EXPECT_EQ(0, GetChildCount(div));
 }
 
 }  // namespace


### PR DESCRIPTION
This fixes all remaining html5lib trunk failures.  The root cause was the tokenizer state not being namespace-aware when comparing with the list of tags.