### PR TITLE
Performance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ CLASSIFIERS = [
 ]
 
 setup(name='gumbo',
-      version='0.9.2',
+      version='0.9.4',
       description='Python bindings for Gumbo HTML parser',
       long_description=README,
       url='http://github.com/google/gumbo-parser',

--- a/src/parser.c
+++ b/src/parser.c
@@ -938,8 +938,7 @@ static void maybe_flush_text_node_buffer(GumboParser* parser) {
     insert_node(parser, text_node, location);
   }
 
-  gumbo_string_buffer_destroy(parser, &buffer_state->_buffer);
-  gumbo_string_buffer_init(parser, &buffer_state->_buffer);
+  gumbo_string_buffer_clear(parser, &buffer_state->_buffer);
   buffer_state->_type = GUMBO_NODE_WHITESPACE;
   assert(buffer_state->_buffer.length == 0);
 }

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -26,7 +26,9 @@
 
 struct GumboInternalParser;
 
-static const size_t kDefaultStringBufferSize = 10;
+// Size chosen via statistical analysis of ~60K websites.
+// 99% of text nodes and 98% of attribute names/values fit in this initial size.
+static const size_t kDefaultStringBufferSize = 5;
 
 static void maybe_resize_string_buffer(
     struct GumboInternalParser* parser, size_t additional_chars,

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -102,6 +102,11 @@ char* gumbo_string_buffer_to_string(
   return buffer;
 }
 
+void gumbo_string_buffer_clear(
+    struct GumboInternalParser* parser, GumboStringBuffer* input) {
+  input->length = 0;
+}
+
 void gumbo_string_buffer_destroy(
     struct GumboInternalParser* parser, GumboStringBuffer* buffer) {
   gumbo_parser_deallocate(parser, buffer->data);

--- a/src/string_buffer.h
+++ b/src/string_buffer.h
@@ -70,6 +70,11 @@ void gumbo_string_buffer_append_string(
 char* gumbo_string_buffer_to_string(
     struct GumboInternalParser* parser, GumboStringBuffer* input);
 
+// Reinitialize this string buffer.  This clears it by setting length=0.  It
+// does not zero out the buffer itself.
+void gumbo_string_buffer_clear(
+    struct GumboInternalParser* parser, GumboStringBuffer* input);
+
 // Deallocates this GumboStringBuffer.
 void gumbo_string_buffer_destroy(
     struct GumboInternalParser* parser, GumboStringBuffer* buffer);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -696,7 +696,7 @@ static void start_new_tag(GumboParser* parser, bool is_start_tag) {
 
   assert(tag_state->_attributes.data == NULL);
   // Initial size chosen by statistical analysis of a corpus of 60k webpages.
-  // 99.5% of elements have 0 elements, 93% of the remainder have 1.  These
+  // 99.5% of elements have 0 attributes, 93% of the remainder have 1.  These
   // numbers are a bit higher for more modern websites (eg. ~45% = 0, ~40% = 1
   // for the HTML5 Spec), but still have basically 99% of nodes with <= 2 attrs.
   gumbo_vector_init(parser, 1, &tag_state->_attributes);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -356,12 +356,10 @@ static void clear_temporary_buffer(GumboParser* parser) {
   GumboTokenizerState* tokenizer = parser->_tokenizer_state;
   assert(!tokenizer->_temporary_buffer_emit);
   utf8iterator_mark(&tokenizer->_input);
-  gumbo_string_buffer_destroy(parser, &tokenizer->_temporary_buffer);
-  gumbo_string_buffer_init(parser, &tokenizer->_temporary_buffer);
+  gumbo_string_buffer_clear(parser, &tokenizer->_temporary_buffer);
   // The temporary buffer and script data buffer are the same object in the
   // spec, so the script data buffer should be cleared as well.
-  gumbo_string_buffer_destroy(parser, &tokenizer->_script_data_buffer);
-  gumbo_string_buffer_init(parser, &tokenizer->_script_data_buffer);
+  gumbo_string_buffer_clear(parser, &tokenizer->_script_data_buffer);
 }
 
 // Appends a codepoint to the temporary buffer.
@@ -1595,8 +1593,7 @@ static StateResult handle_script_double_escaped_lt_state(
     int c, GumboToken* output) {
   if (c == '/') {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DOUBLE_ESCAPED_END);
-    gumbo_string_buffer_destroy(parser, &tokenizer->_script_data_buffer);
-    gumbo_string_buffer_init(parser, &tokenizer->_script_data_buffer);
+    gumbo_string_buffer_clear(parser, &tokenizer->_script_data_buffer);
     return emit_current_char(parser, output);
   } else {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DOUBLE_ESCAPED);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -697,7 +697,11 @@ static void start_new_tag(GumboParser* parser, bool is_start_tag) {
   gumbo_string_buffer_append_codepoint(parser, c, &tag_state->_buffer);
 
   assert(tag_state->_attributes.data == NULL);
-  gumbo_vector_init(parser, 4, &tag_state->_attributes);
+  // Initial size chosen by statistical analysis of a corpus of 60k webpages.
+  // 99.5% of elements have 0 elements, 93% of the remainder have 1.  These
+  // numbers are a bit higher for more modern websites (eg. ~45% = 0, ~40% = 1
+  // for the HTML5 Spec), but still have basically 99% of nodes with <= 2 attrs.
+  gumbo_vector_init(parser, 1, &tag_state->_attributes);
   tag_state->_drop_next_attr_value = false;
   tag_state->_is_start_tag = is_start_tag;
   tag_state->_is_self_closing = false;

--- a/tests/string_buffer.cc
+++ b/tests/string_buffer.cc
@@ -95,6 +95,7 @@ TEST_F(GumboStringBufferTest, AppendCodepoint_4Bytes) {
 }
 
 TEST_F(GumboStringBufferTest, ToString) {
+  gumbo_string_buffer_reserve(&parser_, 8, &buffer_);
   strcpy(buffer_.data, "012345");
   buffer_.length = 7;
 


### PR DESCRIPTION
Two main performance fixes, along with fixes for some bugs that they exposed:

1. Resize the default sizes for vector/stringbuffer allocations, based on statistical analysis of a corpus of webpages.
2. Clear temporary buffers instead of releasing and reinitializing them.
3. Fix va_args behavior to avoid possible memory corruption caused by misuse of vsnprintf.
4. Fix unit tests to avoid implicit dependency on size of buffers.