### PR TITLE
Fix 2 memory leaks

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2873,6 +2873,13 @@ static bool handle_in_body(GumboParser* parser, GumboToken* token) {
     // touching the attributes.
     ignore_token(parser);
 
+    // The name attribute, if present, should be destroyed since it's ignored
+    // when copying over.  The action attribute should be kept since it's moved
+    // to the form.
+    if (name_attr) {
+      gumbo_destroy_attribute(parser, name_attr);
+    }
+
     GumboAttribute* name =
         gumbo_parser_allocate(parser, sizeof(GumboAttribute));
     GumboStringPiece name_str = GUMBO_STRING("name");

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -26,12 +26,15 @@ namespace {
 class GumboParserTest : public ::testing::Test {
  protected:
   GumboParserTest() :
-    options_(kGumboDefaultOptions), output_(NULL), root_(NULL) {}
+    options_(kGumboDefaultOptions), output_(NULL), root_(NULL) {
+    InitLeakDetection(&options_, &malloc_stats_);
+  }
 
   virtual ~GumboParserTest() {
     if (output_) {
       gumbo_destroy_output(&options_, output_);
     }
+    EXPECT_EQ(malloc_stats_.objects_allocated, malloc_stats_.objects_freed);
   }
 
   virtual void Parse(const char* input) {
@@ -69,6 +72,7 @@ class GumboParserTest : public ::testing::Test {
     SanityCheckPointers(input.data(), input.length(), output_->root, 1000);
   }
 
+  MallocStats malloc_stats_;
   GumboOptions options_;
   GumboOutput* output_;
   GumboNode* root_;


### PR DESCRIPTION
This fixes memory leaks in:

1. clone_node, where the new node wasn't being linked into the next/prev list.  This also is a behavioral bug, as traversals would skip it.
2. isindex handling, where the 'name' attribute would leak if one was supplied on the tag.

It also updates the parser unit tests to apply leak detection when running, to avoid similar problems in the future.