### PR TITLE
Arena

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,8 @@ lib_LTLIBRARIES = libgumbo.la
 libgumbo_la_CFLAGS = -Wall
 libgumbo_la_LDFLAGS = -version-info 1:0:0 -no-undefined
 libgumbo_la_SOURCES = \
+				src/arena.c \
+				src/arena.h \
 				src/attribute.c \
 				src/attribute.h \
 				src/char_ref.c \

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ CLASSIFIERS = [
 ]
 
 setup(name='gumbo',
-      version='0.9.2',
+      version='0.9.4',
       description='Python bindings for Gumbo HTML parser',
       long_description=README,
       url='http://github.com/google/gumbo-parser',

--- a/src/arena.c
+++ b/src/arena.c
@@ -1,0 +1,60 @@
+// Copyright 2015 Jonathan Tang. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: jonathan.d.tang@gmail.com (Jonathan Tang)
+
+#include "arena.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "util.h"
+
+void arena_init(GumboArena* arena) {
+  assert(arena != NULL);
+  arena->head = malloc(sizeof(GumboArenaChunk));
+  arena->head->next = NULL;
+  arena->allocation_ptr = arena->head->data;
+  gumbo_debug("Initializing arena @%x\n", arena->head);
+}
+
+void arena_destroy(GumboArena* arena) {
+  GumboArenaChunk* chunk = arena->head;
+  while (chunk) {
+    gumbo_debug("Freeing arena chunk @%x\n", chunk);
+    GumboArenaChunk* to_free = chunk;
+    chunk = chunk->next;
+    free(to_free);
+  }
+}
+
+void* gumbo_arena_malloc(void* userdata, size_t size) {
+  GumboArena* arena = userdata;
+  GumboArenaChunk* current_chunk = arena->head;
+  if (arena->allocation_ptr >= current_chunk->data + CHUNK_SIZE - size) {
+    GumboArenaChunk* new_chunk = malloc(sizeof(GumboArenaChunk));
+    gumbo_debug("Allocating new arena chunk @%x\n", new_chunk);
+    new_chunk->next = current_chunk;
+    arena->head = new_chunk;
+    arena->allocation_ptr = new_chunk->data;
+  }
+  void* obj = arena->allocation_ptr;
+  arena->allocation_ptr += (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+  return obj;
+}
+
+void arena_free(void* userdata, void* obj) {
+  // No-op.
+}
+

--- a/src/arena.c
+++ b/src/arena.c
@@ -21,12 +21,15 @@
 
 #include "util.h"
 
+unsigned int gChunksAllocated;
+
 void arena_init(GumboArena* arena) {
   assert(arena != NULL);
   arena->head = malloc(sizeof(GumboArenaChunk));
   arena->head->next = NULL;
   arena->allocation_ptr = arena->head->data;
   gumbo_debug("Initializing arena @%x\n", arena->head);
+  gChunksAllocated = 1;
 }
 
 void arena_destroy(GumboArena* arena) {
@@ -50,10 +53,15 @@ void* gumbo_arena_malloc(void* userdata, size_t size) {
     new_chunk->next = current_chunk;
     arena->head = new_chunk;
     arena->allocation_ptr = new_chunk->data;
+    ++gChunksAllocated;
   }
   void* obj = arena->allocation_ptr;
   arena->allocation_ptr += aligned_size;
   return obj;
+}
+
+unsigned int gumbo_arena_chunks_allocated() {
+  return gChunksAllocated;
 }
 
 void arena_free(void* userdata, void* obj) {

--- a/src/arena.c
+++ b/src/arena.c
@@ -42,7 +42,9 @@ void arena_destroy(GumboArena* arena) {
 void* gumbo_arena_malloc(void* userdata, size_t size) {
   GumboArena* arena = userdata;
   GumboArenaChunk* current_chunk = arena->head;
-  if (arena->allocation_ptr >= current_chunk->data + CHUNK_SIZE - size) {
+  size_t aligned_size = (size + ARENA_ALIGNMENT - 1) & ~(ARENA_ALIGNMENT - 1);
+  if (arena->allocation_ptr >=
+      current_chunk->data + ARENA_CHUNK_SIZE - aligned_size) {
     GumboArenaChunk* new_chunk = malloc(sizeof(GumboArenaChunk));
     gumbo_debug("Allocating new arena chunk @%x\n", new_chunk);
     new_chunk->next = current_chunk;
@@ -50,7 +52,7 @@ void* gumbo_arena_malloc(void* userdata, size_t size) {
     arena->allocation_ptr = new_chunk->data;
   }
   void* obj = arena->allocation_ptr;
-  arena->allocation_ptr += (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+  arena->allocation_ptr += aligned_size;
   return obj;
 }
 

--- a/src/arena.h
+++ b/src/arena.h
@@ -23,27 +23,21 @@
 extern "C" {
 #endif
 
-// 400K is right around the median total memory allocation (on a corpus of ~60K
-// webpages taken from CommonCrawl), and allows up to 50K 8-byte allocations.
-// The 95th percentile is roughly 2M, which would give 5 arena chunks.
-// This should allow ~50% of webpages to parse in a single arena chunk, and the
-// vast majority to use no more than 5, while still keeping typical memory usage
-// well under a meg.
-#define ARENA_CHUNK_SIZE 399992
-#define ARENA_ALIGNMENT 8
-
 typedef struct GumboInternalArenaChunk {
   struct GumboInternalArenaChunk* next;
-  char data[ARENA_CHUNK_SIZE];
+  char data[];
 } GumboArenaChunk;
 
 // Initialize an arena, allocating the first chunk for it.
-void arena_init(GumboArena* arena);
+void arena_init(GumboArena* arena, size_t chunk_size);
 
 // Destroy an arena, freeing all memory used by it and all objects contained.
 void arena_destroy(GumboArena* arena);
 
-// gumbo_arena_malloc is defined in gumbo.h
+// Allocate an object in an arena.  chunk_size must remain constant between
+// allocations.  Returns NULL if either the program requests size > chunk_size
+// or the system malloc fails.
+void* arena_malloc(GumboArena* arena, size_t chunk_size, size_t size);
 
 // No-op free function for use as a custom allocator.
 void arena_free(void* arena, void* obj);

--- a/src/arena.h
+++ b/src/arena.h
@@ -1,0 +1,55 @@
+// Copyright 2015 Jonathan Tang. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: jonathan.d.tang@gmail.com (Jonathan Tang)
+
+#ifndef GUMBO_ARENA_H_
+#define GUMBO_ARENA_H_
+
+#include "gumbo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// 400K is right around the median total memory allocation (on a corpus of ~60K
+// webpages taken from CommonCrawl), and allows up to 50K 8-byte allocations.
+// The 95th percentile is roughly 2M, which would give 5 arena chunks.
+// This should allow ~50% of webpages to parse in a single arena chunk, and the
+// vast majority to use no more than 5, while still keeping typical memory usage
+// well under a meg.
+#define CHUNK_SIZE 400000
+#define ALIGNMENT 8
+
+typedef struct GumboInternalArenaChunk {
+  struct GumboInternalArenaChunk* next;
+  char data[CHUNK_SIZE];
+} GumboArenaChunk;
+
+// Initialize an arena, allocating the first chunk for it.
+void arena_init(GumboArena* arena);
+
+// Destroy an arena, freeing all memory used by it and all objects contained.
+void arena_destroy(GumboArena* arena);
+
+// gumbo_arena_malloc is defined in gumbo.h
+
+// No-op free function for use as a custom allocator.
+void arena_free(void* arena, void* obj);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // GUMBO_ARENA_H_

--- a/src/arena.h
+++ b/src/arena.h
@@ -29,12 +29,12 @@ extern "C" {
 // This should allow ~50% of webpages to parse in a single arena chunk, and the
 // vast majority to use no more than 5, while still keeping typical memory usage
 // well under a meg.
-#define CHUNK_SIZE 400000
-#define ALIGNMENT 8
+#define ARENA_CHUNK_SIZE 399992
+#define ARENA_ALIGNMENT 8
 
 typedef struct GumboInternalArenaChunk {
   struct GumboInternalArenaChunk* next;
-  char data[CHUNK_SIZE];
+  char data[ARENA_CHUNK_SIZE];
 } GumboArenaChunk;
 
 // Initialize an arena, allocating the first chunk for it.

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -596,6 +596,17 @@ typedef struct GumboInternalOptions {
    * Default: -1
    */
   int max_errors;
+
+  /**
+   * The memory size of new arena chunks.  The default (800K) is enough to parse
+   * ~60% of webpages in a single chunk; 95% will parse in under 2M.  However,
+   * individual allocations cannot exceed the size of a single chunk; a small
+   * percentage (< 1/1000) of pages have very long text blocks that will be
+   * truncated by this, with the out_of_memory flag set.  If you really need
+   * precise data for them and have extra memory to spend, try increasing this
+   * setting as necessary.
+   */
+  size_t arena_chunk_size;
 } GumboOptions;
 
 /** Default options struct; use this with gumbo_parse_with_options. */
@@ -608,8 +619,6 @@ typedef struct GumboInternalArena {
   struct GumboInternalArenaChunk* head;
   char* allocation_ptr;
 } GumboArena;
-
-void* gumbo_arena_malloc(void* userdata, size_t size);
 
 unsigned int gumbo_arena_chunks_allocated();
 

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -642,6 +642,19 @@ typedef struct GumboInternalOutput {
    * couple pointers) when a custom memory allocator is supplied.
    */
   GumboArena arena;
+
+  /**
+   * Flag set if an out-of-memory condition occurs.  This can either be because
+   * a stringbuffer or vector requested a single chunk larger than the arena
+   * chunk size, or because the system malloc failed.  (The latter is not
+   * implemented yet - on most modern OSes, malloc never returns NULL and
+   * instead overcommits virtual memory.)  Gumbo makes its best effort to
+   * recover from OOM errors: if the reason was that a buffer exceeded maximum
+   * chunk size, it truncates that buffer at the maximum chunk size, refuses to
+   * write to it anymore, and continues parsing.  If the system malloc fails, it
+   * returns the parse tree it's parsed up until that point.
+   */
+  bool out_of_memory;
 } GumboOutput;
 
 /**

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -576,18 +576,6 @@ typedef void (*GumboDeallocatorFunction)(void* userdata, void* ptr);
  * Use kGumboDefaultOptions for sensible defaults, and only set what you need.
  */
 typedef struct GumboInternalOptions {
-  /** A memory allocator function.  Default: malloc. */
-  GumboAllocatorFunction allocator;
-
-  /** A memory deallocator function. Default: free. */
-  GumboDeallocatorFunction deallocator;
-
-  /**
-   * An opaque object that's passed in as the first argument to all callbacks
-   * used by this library.  Default: NULL.
-   */
-  void* userdata;
-
   /**
    * The tab-stop size, for computing positions in source code that uses tabs.
    * Default: 8.
@@ -613,6 +601,16 @@ typedef struct GumboInternalOptions {
 /** Default options struct; use this with gumbo_parse_with_options. */
 extern const GumboOptions kGumboDefaultOptions;
 
+/** Base struct for an arena. */
+struct GumboInternalArenaChunk;
+
+typedef struct GumboInternalArena {
+  struct GumboInternalArenaChunk* head;
+  char* allocation_ptr;
+} GumboArena;
+
+void* gumbo_arena_malloc(void* userdata, size_t size);
+
 /** The output struct containing the results of the parse. */
 typedef struct GumboInternalOutput {
   /**
@@ -635,6 +633,13 @@ typedef struct GumboInternalOutput {
    * reported so we can work out something appropriate for your use-case.
    */
   GumboVector /* GumboError */ errors;
+
+  /**
+   * Arena for default memory allocation.  This is initialized on parse start
+   * when using the default memory allocator; it consumes little memory (a
+   * couple pointers) when a custom memory allocator is supplied.
+   */
+  GumboArena arena;
 } GumboOutput;
 
 /**

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -611,6 +611,8 @@ typedef struct GumboInternalArena {
 
 void* gumbo_arena_malloc(void* userdata, size_t size);
 
+unsigned int gumbo_arena_chunks_allocated();
+
 /** The output struct containing the results of the parse. */
 typedef struct GumboInternalOutput {
   /**

--- a/src/parser.c
+++ b/src/parser.c
@@ -938,8 +938,7 @@ static void maybe_flush_text_node_buffer(GumboParser* parser) {
     insert_node(parser, text_node, location);
   }
 
-  gumbo_string_buffer_destroy(parser, &buffer_state->_buffer);
-  gumbo_string_buffer_init(parser, &buffer_state->_buffer);
+  gumbo_string_buffer_clear(parser, &buffer_state->_buffer);
   buffer_state->_type = GUMBO_NODE_WHITESPACE;
   assert(buffer_state->_buffer.length == 0);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -61,6 +61,7 @@ const GumboOptions kGumboDefaultOptions = {
   8,
   false,
   -1,
+  799992,
 };
 
 static const GumboStringPiece kDoctypeHtml = GUMBO_STRING("html");
@@ -4050,7 +4051,7 @@ GumboOutput* gumbo_parse_fragment(
   // arena is stored in the GumboOutput structure, so that must be allocated
   // manually.
   parser._output = malloc(sizeof(GumboOutput));
-  arena_init(&parser._output->arena);
+  arena_init(&parser._output->arena, options->arena_chunk_size);
   // Next initialize the parser state.
   parser_state_init(&parser);
   // Must come after parser_state_init, since creating the document node must
@@ -4074,6 +4075,11 @@ GumboOutput* gumbo_parse_fragment(
 
   GumboToken token;
   bool has_error = false;
+
+  if (setjmp(parser._out_of_memory_jmp)) {
+    parser._output->out_of_memory = true;
+    return parser._output;
+  }
 
   do {
     if (state->_reprocess_current_token) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <strings.h>
 
+#include "arena.h"
 #include "attribute.h"
 #include "error.h"
 #include "gumbo.h"
@@ -56,18 +57,7 @@ static bool handle_in_template(GumboParser*, GumboToken*);
 static GumboNode* destroy_node(GumboParser*, GumboNode*);
 
 
-static void* malloc_wrapper(void* unused, size_t size) {
-  return malloc(size);
-}
-
-static void free_wrapper(void* unused, void* ptr) {
-  free(ptr);
-}
-
 const GumboOptions kGumboDefaultOptions = {
-  &malloc_wrapper,
-  &free_wrapper,
-  NULL,
   8,
   false,
   -1,
@@ -501,11 +491,9 @@ static GumboNode* new_document_node(GumboParser* parser) {
   return document_node;
 }
 
-static void output_init(GumboParser* parser) {
-  GumboOutput* output = gumbo_parser_allocate(parser, sizeof(GumboOutput));
+static void output_init(GumboParser* parser, GumboOutput* output) {
   output->root = NULL;
   output->document = new_document_node(parser);
-  parser->_output = output;
   gumbo_init_errors(parser);
 }
 
@@ -4055,10 +4043,16 @@ GumboOutput* gumbo_parse_fragment(
     const GumboTag fragment_ctx, const GumboNamespaceEnum fragment_namespace) {
   GumboParser parser;
   parser._options = options;
+  // Must come first, since all the other init functions allocate memory.  The
+  // arena is stored in the GumboOutput structure, so that must be allocated
+  // manually.
+  parser._output = malloc(sizeof(GumboOutput));
+  arena_init(&parser._output->arena);
+  // Next initialize the parser state.
   parser_state_init(&parser);
   // Must come after parser_state_init, since creating the document node must
   // reference parser_state->_current_node.
-  output_init(&parser);
+  output_init(&parser, parser._output);
   // And this must come after output_init, because initializing the tokenizer
   // reads the first character and that may cause a UTF-8 decode error
   // (inserting into output->errors) if that's invalid.
@@ -4155,18 +4149,6 @@ GumboOutput* gumbo_parse_fragment(
 }
 
 void gumbo_destroy_output(const GumboOptions* options, GumboOutput* output) {
-  // Need a dummy GumboParser because the allocator comes along with the
-  // options object.
-  GumboParser parser;
-  parser._parser_state = NULL;
-  parser._options = options;
-  GumboNode* current = output->document;
-  while (current) {
-    current = destroy_node(&parser, current);
-  }
-  for (int i = 0; i < output->errors.length; ++i) {
-    gumbo_error_destroy(&parser, output->errors.data[i]);
-  }
-  gumbo_vector_destroy(&parser, &output->errors);
-  gumbo_parser_deallocate(&parser, output);
+  arena_destroy(&output->arena);
+  free(output);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -494,6 +494,9 @@ static GumboNode* new_document_node(GumboParser* parser) {
 static void output_init(GumboParser* parser, GumboOutput* output) {
   output->root = NULL;
   output->document = new_document_node(parser);
+  // Arena is initialized before this is called, so we have memory to initialize
+  // the parser state.
+  output->out_of_memory = false;
   gumbo_init_errors(parser);
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -20,6 +20,8 @@
 #ifndef GUMBO_PARSER_H_
 #define GUMBO_PARSER_H_
 
+#include <setjmp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -48,6 +50,10 @@ typedef struct GumboInternalParser {
   // The internal parser state.  Initialized on parse start and destroyed on
   // parse end; end-users will never see a non-garbage value in this pointer.
   struct GumboInternalParserState* _parser_state;
+
+  // A jmp_buf to use in case of out-of-memory conditions.  This jumps back to
+  // gumbo_parse, which then returns after setting the out_of_memory flag.
+  jmp_buf _out_of_memory_jmp;
 } GumboParser;
 
 #ifdef __cplusplus

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -27,8 +27,10 @@
 struct GumboInternalParser;
 
 // Size chosen via statistical analysis of ~60K websites.
-// 99% of text nodes and 98% of attribute names/values fit in this initial size.
-static const size_t kDefaultStringBufferSize = 6;
+// 99% of text nodes and 98% of attribute names/values fit within 5 characters.
+// Since the arena allocator only ever returns word-aligned chunks, however, it
+// makes no sense to use less than 8 chars.
+static const size_t kDefaultStringBufferSize = 8;
 
 static void maybe_resize_string_buffer(
     struct GumboInternalParser* parser, size_t additional_chars,

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -21,7 +21,8 @@
 #include <string.h>
 #include <strings.h>
 
-#include "arena.h"
+#include "gumbo.h"
+#include "parser.h"
 #include "string_piece.h"
 #include "util.h"
 
@@ -42,8 +43,8 @@ static bool maybe_resize_string_buffer(
     new_capacity *= 2;
   }
   if (new_capacity != buffer->capacity) {
-    if (new_capacity > ARENA_CHUNK_SIZE) {
-      if (buffer->capacity == ARENA_CHUNK_SIZE) {
+    if (new_capacity > parser->_options->arena_chunk_size) {
+      if (buffer->capacity == parser->_options->arena_chunk_size) {
         // If we have already resized the buffer to the maximum chunk size, then
         // we're out of memory, and we ignore any more writes to the buffer.
         gumbo_set_out_of_memory(parser);
@@ -52,7 +53,7 @@ static bool maybe_resize_string_buffer(
       // Otherwise, this is the first time we've hit the new max.  Resize the
       // allocation to take up a whole chunk, but don't set an error condition
       // and let writes proceed.
-      new_capacity = ARENA_CHUNK_SIZE;
+      new_capacity = parser->_options->arena_chunk_size;
     }
     char* new_data = gumbo_parser_allocate(parser, new_capacity);
     memcpy(new_data, buffer->data, buffer->length);

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -28,7 +28,7 @@ struct GumboInternalParser;
 
 // Size chosen via statistical analysis of ~60K websites.
 // 99% of text nodes and 98% of attribute names/values fit in this initial size.
-static const size_t kDefaultStringBufferSize = 5;
+static const size_t kDefaultStringBufferSize = 6;
 
 static void maybe_resize_string_buffer(
     struct GumboInternalParser* parser, size_t additional_chars,
@@ -96,9 +96,10 @@ void gumbo_string_buffer_append_string(
 
 char* gumbo_string_buffer_to_string(
     struct GumboInternalParser* parser, GumboStringBuffer* input) {
-  char* buffer = gumbo_parser_allocate(parser, input->length + 1);
-  memcpy(buffer, input->data, input->length);
+  maybe_resize_string_buffer(parser, input->length + 1, input);
+  char* buffer = input->data;
   buffer[input->length] = '\0';
+  gumbo_string_buffer_init(parser, input);
   return buffer;
 }
 

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -105,6 +105,13 @@ char* gumbo_string_buffer_to_string(
 void gumbo_string_buffer_clear(
     struct GumboInternalParser* parser, GumboStringBuffer* input) {
   input->length = 0;
+  if (input->capacity > kDefaultStringBufferSize * 8) {
+    // This approach to clearing means that the buffer can grow unbounded and
+    // tie up memory that may be needed for parsing the rest of the document, so
+    // we free and reinitialize the buffer if its grown more than 3 doublings.
+    gumbo_string_buffer_destroy(parser, input);
+    gumbo_string_buffer_init(parser, input);
+  }
 }
 
 void gumbo_string_buffer_destroy(

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -26,7 +26,9 @@
 
 struct GumboInternalParser;
 
-static const size_t kDefaultStringBufferSize = 10;
+// Size chosen via statistical analysis of ~60K websites.
+// 99% of text nodes and 98% of attribute names/values fit in this initial size.
+static const size_t kDefaultStringBufferSize = 5;
 
 static void maybe_resize_string_buffer(
     struct GumboInternalParser* parser, size_t additional_chars,

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -102,6 +102,11 @@ char* gumbo_string_buffer_to_string(
   return buffer;
 }
 
+void gumbo_string_buffer_clear(
+    struct GumboInternalParser* parser, GumboStringBuffer* input) {
+  input->length = 0;
+}
+
 void gumbo_string_buffer_destroy(
     struct GumboInternalParser* parser, GumboStringBuffer* buffer) {
   gumbo_parser_deallocate(parser, buffer->data);

--- a/src/string_buffer.h
+++ b/src/string_buffer.h
@@ -70,6 +70,11 @@ void gumbo_string_buffer_append_string(
 char* gumbo_string_buffer_to_string(
     struct GumboInternalParser* parser, GumboStringBuffer* input);
 
+// Reinitialize this string buffer.  This clears it by setting length=0.  It
+// does not zero out the buffer itself.
+void gumbo_string_buffer_clear(
+    struct GumboInternalParser* parser, GumboStringBuffer* input);
+
 // Deallocates this GumboStringBuffer.
 void gumbo_string_buffer_destroy(
     struct GumboInternalParser* parser, GumboStringBuffer* buffer);

--- a/src/string_buffer.h
+++ b/src/string_buffer.h
@@ -50,8 +50,9 @@ void gumbo_string_buffer_init(
 
 // Ensures that the buffer contains at least a certain amount of space.  Most
 // useful with snprintf and the other length-delimited string functions, which
-// may want to write directly into the buffer.
-void gumbo_string_buffer_reserve(
+// may want to write directly into the buffer.  Returns false on an allocation
+// failure - the client should *not* try to write to the buffer in this case.
+bool gumbo_string_buffer_reserve(
     struct GumboInternalParser* parser, size_t min_capacity,
     GumboStringBuffer* output);
 

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -356,12 +356,10 @@ static void clear_temporary_buffer(GumboParser* parser) {
   GumboTokenizerState* tokenizer = parser->_tokenizer_state;
   assert(!tokenizer->_temporary_buffer_emit);
   utf8iterator_mark(&tokenizer->_input);
-  gumbo_string_buffer_destroy(parser, &tokenizer->_temporary_buffer);
-  gumbo_string_buffer_init(parser, &tokenizer->_temporary_buffer);
+  gumbo_string_buffer_clear(parser, &tokenizer->_temporary_buffer);
   // The temporary buffer and script data buffer are the same object in the
   // spec, so the script data buffer should be cleared as well.
-  gumbo_string_buffer_destroy(parser, &tokenizer->_script_data_buffer);
-  gumbo_string_buffer_init(parser, &tokenizer->_script_data_buffer);
+  gumbo_string_buffer_clear(parser, &tokenizer->_script_data_buffer);
 }
 
 // Appends a codepoint to the temporary buffer.
@@ -1595,8 +1593,7 @@ static StateResult handle_script_double_escaped_lt_state(
     int c, GumboToken* output) {
   if (c == '/') {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DOUBLE_ESCAPED_END);
-    gumbo_string_buffer_destroy(parser, &tokenizer->_script_data_buffer);
-    gumbo_string_buffer_init(parser, &tokenizer->_script_data_buffer);
+    gumbo_string_buffer_clear(parser, &tokenizer->_script_data_buffer);
     return emit_current_char(parser, output);
   } else {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DOUBLE_ESCAPED);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -697,7 +697,11 @@ static void start_new_tag(GumboParser* parser, bool is_start_tag) {
   gumbo_string_buffer_append_codepoint(parser, c, &tag_state->_buffer);
 
   assert(tag_state->_attributes.data == NULL);
-  gumbo_vector_init(parser, 4, &tag_state->_attributes);
+  // Initial size chosen by statistical analysis of a corpus of 60k webpages.
+  // 99.5% of elements have 0 elements, 93% of the remainder have 1.  These
+  // numbers are a bit higher for more modern websites (eg. ~45% = 0, ~40% = 1
+  // for the HTML5 Spec), but still have basically 99% of nodes with <= 2 attrs.
+  gumbo_vector_init(parser, 1, &tag_state->_attributes);
   tag_state->_drop_next_attr_value = false;
   tag_state->_is_start_tag = is_start_tag;
   tag_state->_is_self_closing = false;

--- a/src/util.c
+++ b/src/util.c
@@ -43,6 +43,10 @@ char* gumbo_copy_stringz(GumboParser* parser, const char* str) {
   return buffer;
 }
 
+void gumbo_set_out_of_memory(GumboParser* parser) {
+  parser->_output->out_of_memory = true;
+}
+
 // Debug function to trace operation of the parser.  Pass --copts=-DGUMBO_DEBUG
 // to use.
 void gumbo_debug(const char* format, ...) {

--- a/src/util.c
+++ b/src/util.c
@@ -32,12 +32,10 @@
 const GumboSourcePosition kGumboEmptySourcePosition = { 0, 0, 0 };
 
 void* gumbo_parser_allocate(GumboParser* parser, size_t num_bytes) {
-  return parser->_options->allocator(parser->_options->userdata, num_bytes);
+  return gumbo_arena_malloc(&parser->_output->arena, num_bytes);
 }
 
-void gumbo_parser_deallocate(GumboParser* parser, void* ptr) {
-  parser->_options->deallocator(parser->_options->userdata, ptr);
-}
+void gumbo_parser_deallocate(GumboParser* parser, void* ptr) {}
 
 char* gumbo_copy_stringz(GumboParser* parser, const char* str) {
   char* buffer = gumbo_parser_allocate(parser, strlen(str) + 1);

--- a/src/util.h
+++ b/src/util.h
@@ -51,6 +51,9 @@ void* gumbo_parser_allocate(
 // config options.
 void gumbo_parser_deallocate(struct GumboInternalParser* parser, void* ptr);
 
+// Sets the out-of-memory flag on the output.
+void gumbo_set_out_of_memory(struct GumboInternalParser* parser);
+
 // Debug wrapper for printf, to make it easier to turn off debugging info when
 // required.
 void gumbo_debug(const char* format, ...);

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -74,6 +74,22 @@ class GumboParserTest : public ::testing::Test {
   GumboNode* root_;
 };
 
+TEST_F(GumboParserTest, OutOfMemory) {
+  std::string html("<ul>");
+  for (int i = 0; i < 1000; ++i) {
+    html += "<li>This should create a child vector larger than the chunk.";
+  }
+  html += "</ul>";
+
+  options_.arena_chunk_size = 4000;
+  Parse(html);
+
+  EXPECT_TRUE(output_->out_of_memory);
+  // The partial parse tree should still be constructed.
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+}
+
 TEST_F(GumboParserTest, NullDocument) {
   Parse("");
   ASSERT_TRUE(root_);

--- a/tests/string_buffer.cc
+++ b/tests/string_buffer.cc
@@ -95,6 +95,7 @@ TEST_F(GumboStringBufferTest, AppendCodepoint_4Bytes) {
 }
 
 TEST_F(GumboStringBufferTest, ToString) {
+  gumbo_string_buffer_reserve(&parser_, 8, &buffer_);
   strcpy(buffer_.data, "012345");
   buffer_.length = 7;
 

--- a/tests/string_buffer.cc
+++ b/tests/string_buffer.cc
@@ -47,7 +47,7 @@ class GumboStringBufferTest : public GumboTest {
 
 TEST_F(GumboStringBufferTest, Reserve) {
   gumbo_string_buffer_reserve(&parser_, 21, &buffer_);
-  EXPECT_EQ(24, buffer_.capacity);
+  EXPECT_EQ(32, buffer_.capacity);
   strcpy(buffer_.data, "01234567890123456789");
   buffer_.length = 20;
   NullTerminateBuffer();

--- a/tests/string_buffer.cc
+++ b/tests/string_buffer.cc
@@ -47,7 +47,7 @@ class GumboStringBufferTest : public GumboTest {
 
 TEST_F(GumboStringBufferTest, Reserve) {
   gumbo_string_buffer_reserve(&parser_, 21, &buffer_);
-  EXPECT_EQ(40, buffer_.capacity);
+  EXPECT_EQ(24, buffer_.capacity);
   strcpy(buffer_.data, "01234567890123456789");
   buffer_.length = 20;
   NullTerminateBuffer();

--- a/tests/string_piece.cc
+++ b/tests/string_piece.cc
@@ -74,13 +74,12 @@ TEST_F(GumboStringPieceTest, CaseNotEqual_Str2Shorter) {
 }
 
 TEST_F(GumboStringPieceTest, Copy) {
-  GumboParser parser;
-  parser._options = &kGumboDefaultOptions;
+  GumboParser* parser = &parser_;
   INIT_GUMBO_STRING(str1, "bar");
   GumboStringPiece str2;
-  gumbo_string_copy(&parser, &str2, &str1);
+  gumbo_string_copy(parser, &str2, &str1);
   EXPECT_TRUE(gumbo_string_equals(&str1, &str2));
-  gumbo_parser_deallocate(&parser, (void*) str2.data);
+  gumbo_parser_deallocate(parser, (void*) str2.data);
 }
 
 }  // namespace

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -150,7 +150,7 @@ GumboTest::GumboTest() :
   options_.max_errors = 100;
   parser_._options = &options_;
   parser_._output = static_cast<GumboOutput*>(calloc(1, sizeof(GumboOutput)));
-  arena_init(&parser_._output->arena);
+  arena_init(&parser_._output->arena, options_.arena_chunk_size);
   gumbo_init_errors(&parser_);
 }
 


### PR DESCRIPTION
Replace the customizable memory allocators with an arena, with the arena being stored in the GumboOutput and freed en-masse when the parse tree is destroyed.  This also adds out-of-memory handling to the library: an OOM error causes the parser to stop parsing immediately but return the parse tree that it does have to the caller.  It builds on the earlier 'performance' pull request, and currently includes commits from that.

Benchmarks are quite promising for this; the exact numbers are in the commits, but seem to indicate a 15-20% performance increase and memory usage that's under 800K for >50% of webpages and under 2M for >95%.  There'll need to be some public discussion about whether people are okay with removing the customizable allocators, since this is not backwards-compatible.  My early impression is that they're not used by many people, though.

There will likely be a few more cleanup commits added to this - I have to remove the stat-gathering function that was only used for benchmarking, and am tempted to remove the GumboOptions argument from gumbo_destroy_output now that it is no longer needed.