### PR TITLE
Fragment api cleanup

### DIFF
--- a/python/gumbo/gumboc.py
+++ b/python/gumbo/gumboc.py
@@ -361,6 +361,8 @@ class Options(ctypes.Structure):
       ('tab_stop', ctypes.c_int),
       ('stop_on_first_error', ctypes.c_bool),
       ('max_errors', ctypes.c_int),
+      ('fragment_context', Tag),
+      ('fragment_namespace', Namespace),
       ]
 
 
@@ -375,8 +377,6 @@ class Output(ctypes.Structure):
 @contextlib.contextmanager
 def parse(text, **kwargs):
   options = Options()
-  context_tag = kwargs.get('container', Tag.LAST)
-  context_namespace = kwargs.get('container_namespace', Namespace.HTML)
   for field_name, _ in Options._fields_:
     try:
       setattr(options, field_name, kwargs[field_name])
@@ -387,9 +387,7 @@ def parse(text, **kwargs):
   # call, it creates a temporary buffer which is destroyed when the call
   # completes, and then the original_text pointers point into invalid memory.
   text_ptr = ctypes.c_char_p(text.encode('utf-8'))
-  output = _parse_fragment(
-      ctypes.byref(options), text_ptr, len(text),
-      context_tag, context_namespace)
+  output = _parse_with_options(ctypes.byref(options), text_ptr, len(text))
   try:
     yield output
   finally:
@@ -400,11 +398,6 @@ _DEFAULT_OPTIONS = Options.in_dll(_dll, 'kGumboDefaultOptions')
 _parse_with_options = _dll.gumbo_parse_with_options
 _parse_with_options.argtypes = [_Ptr(Options), ctypes.c_char_p, ctypes.c_size_t]
 _parse_with_options.restype = _Ptr(Output)
-
-_parse_fragment = _dll.gumbo_parse_fragment
-_parse_fragment.argtypes = [
-    _Ptr(Options), ctypes.c_char_p, ctypes.c_size_t, Tag, Namespace]
-_parse_fragment.restype = _Ptr(Output)
 
 _tag_from_original_text = _dll.gumbo_tag_from_original_text
 _tag_from_original_text.argtypes = [_Ptr(StringPiece)]

--- a/python/gumbo/gumboc_test.py
+++ b/python/gumbo/gumboc_test.py
@@ -117,8 +117,8 @@ class CtypesTest(unittest.TestCase):
   def testFragment(self):
     with gumboc.parse(
         '<div></div>',
-        container=gumboc.Tag.TITLE,
-        container_namespace=gumboc.Namespace.SVG) as output:
+        fragment_context=gumboc.Tag.TITLE,
+        fragment_namespace=gumboc.Namespace.SVG) as output:
       root = output.contents.root.contents
       self.assertEquals(1, len(root.children))
       div = root.children[0]

--- a/python/gumbo/html5lib_adapter.py
+++ b/python/gumbo/html5lib_adapter.py
@@ -129,8 +129,8 @@ class HTMLParser(object):
 
     with gumboc.parse(
         text,
-        container=gumboc.Tag.from_str(container),
-        container_namespace=getattr(gumboc.Namespace, container_ns.upper()),
+        fragment_context=gumboc.Tag.from_str(container),
+        fragment_namespace=getattr(gumboc.Namespace, container_ns.upper()),
         **kwargs) as output:
       for node in output.contents.document.contents.children:
         if node.type in (gumboc.NodeType.ELEMENT, gumboc.NodeType.TEMPLATE):

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -608,6 +608,29 @@ typedef struct GumboInternalOptions {
    * Default: -1
    */
   int max_errors;
+
+  /**
+   * The fragment context for parsing:
+   * https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
+   *
+   * If GUMBO_TAG_LAST is passed here, it is assumed to be "no fragment", i.e.
+   * the regular parsing algorithm.  Otherwise, pass the tag enum for the
+   * intended parent of the parsed fragment.  We use just the tag enum rather
+   * than a full node because that's enough to set all the parsing context we
+   * need, and it provides some additional flexibility for client code to act as
+   * if parsing a fragment even when a full HTML tree isn't available.
+   *
+   * Default: GUMBO_TAG_LAST
+   */
+  GumboTag fragment_context;
+
+  /**
+   * The namespace for the fragment context.  This lets client code
+   * differentiate between, say, parsing a <title> tag in SVG vs. parsing it in
+   * HTML.
+   * Default: GUMBO_NAMESPACE_HTML
+   */
+  GumboNamespaceEnum fragment_namespace;
 } GumboOptions;
 
 /** Default options struct; use this with gumbo_parse_with_options. */
@@ -652,14 +675,6 @@ GumboOutput* gumbo_parse(const char* buffer);
  */
 GumboOutput* gumbo_parse_with_options(
     const GumboOptions* options, const char* buffer, size_t buffer_length);
-
-/**
- * Parse a chunk of HTML with the given fragment context. If `fragment_ctx`
- * is `GUMBO_TAG_LAST`, the fragment will be parsed as a full document.
- */
-GumboOutput* gumbo_parse_fragment(
-    const GumboOptions* options, const char* buffer, size_t length,
-    const GumboTag fragment_ctx, const GumboNamespaceEnum fragment_namespace);
 
 /** Release the memory used for the parse tree & parse errors. */
 void gumbo_destroy_output(

--- a/src/parser.c
+++ b/src/parser.c
@@ -71,6 +71,8 @@ const GumboOptions kGumboDefaultOptions = {
   8,
   false,
   -1,
+  GUMBO_TAG_LAST,
+  GUMBO_NAMESPACE_HTML
 };
 
 static const GumboStringPiece kDoctypeHtml = GUMBO_STRING("html");
@@ -4059,13 +4061,6 @@ GumboOutput* gumbo_parse(const char* buffer) {
 
 GumboOutput* gumbo_parse_with_options(
     const GumboOptions* options, const char* buffer, size_t length) {
-  return gumbo_parse_fragment(
-      options, buffer, length, GUMBO_TAG_LAST, GUMBO_NAMESPACE_HTML);
-}
-
-GumboOutput* gumbo_parse_fragment(
-    const GumboOptions* options, const char* buffer, size_t length,
-    const GumboTag fragment_ctx, const GumboNamespaceEnum fragment_namespace) {
   GumboParser parser;
   parser._options = options;
   parser_state_init(&parser);
@@ -4077,8 +4072,9 @@ GumboOutput* gumbo_parse_fragment(
   // (inserting into output->errors) if that's invalid.
   gumbo_tokenizer_state_init(&parser, buffer, length);
 
-  if (fragment_ctx != GUMBO_TAG_LAST) {
-    fragment_parser_init(&parser, fragment_ctx, fragment_namespace);
+  if (options->fragment_context != GUMBO_TAG_LAST) {
+    fragment_parser_init(
+        &parser, options->fragment_context, options->fragment_namespace);
   }
 
   GumboParserState* state = parser._parser_state;

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -55,8 +55,9 @@ class GumboParserTest : public ::testing::Test {
       gumbo_destroy_output(&options_, output_);
     }
 
-    output_ = gumbo_parse_fragment(
-        &options_, input, strlen(input), context, context_ns);
+    options_.fragment_context = context;
+    options_.fragment_namespace = context_ns;
+    output_ = gumbo_parse_with_options(&options_, input, strlen(input));
     root_ = output_->document;
   }
 


### PR DESCRIPTION
This removes gumbo_parse_fragment and instead moves the fragment context and namespace to GumboOptions, where they have easy defaults.  The ctypes bindings now use 'fragment_context' and 'fragment_namespace' as keyword arguments instead of 'container' and 'container_ns', to match the C API.  Logic remains unchanged.

The main rationale for this is to keep the API surface small for wrapper libraries that may need to provide their own options.