### PR TITLE
Remove next/prev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,7 @@ config.log
 config.status
 config.sub
 configure
-core
 depcomp
-gtest/
 gumbo.pc
 gumbo_test
 gumbo_test.log

--- a/python/gumbo/gumboc.py
+++ b/python/gumbo/gumboc.py
@@ -341,8 +341,6 @@ Node._fields_ = [
     ('type', NodeType),
     # Set the type to Node later to avoid a circular dependency.
     ('parent', _Ptr(Node)),
-    ('next', _Ptr(Node)),
-    ('prev', _Ptr(Node)),
     ('index_within_parent', ctypes.c_size_t),
     # TODO(jdtang): Make a real list of enum constants for this.
     ('parse_flags', _bitvector),

--- a/python/gumbo/gumboc_test.py
+++ b/python/gumbo/gumboc_test.py
@@ -60,14 +60,6 @@ class CtypesTest(unittest.TestCase):
       self.assertEquals(gumboc.NodeType.TEXT, text_node.type)
       self.assertEquals('Test', text_node.text)
 
-      self.assertEquals(gumboc.Tag.HEAD, root.next.contents.tag)
-      self.assertEquals(gumboc.Tag.BODY, head.next.contents.tag)
-      self.assertEquals(gumboc.NodeType.TEXT, body.next.contents.type)
-      self.assertEquals(gumboc.Tag.BODY, text_node.prev.contents.tag)
-      self.assertEquals(gumboc.Tag.HEAD, body.prev.contents.tag)
-      self.assertEquals(gumboc.Tag.HTML, head.prev.contents.tag)
-      self.assertEquals(gumboc.NodeType.DOCUMENT, root.prev.contents.type)
-
   def testBufferThatGoesAway(self):
     for i in range(10):
       source = StringIO.StringIO('<foo bar=quux>1<p>2</foo>')

--- a/python/gumbo/soup_adapter.py
+++ b/python/gumbo/soup_adapter.py
@@ -22,7 +22,6 @@ can then manipulate like a normal BeautifulSoup parse tree.
 __author__ = 'jdtang@google.com (Jonathan Tang)'
 
 import BeautifulSoup
-import ctypes
 
 import gumboc
 
@@ -41,16 +40,6 @@ def _add_source_info(obj, original_text, start_pos, end_pos):
   obj.end_offset = end_pos.offset
 
 
-def _add_document(element):
-  # Currently ignored, since there's no real place for this in the BeautifulSoup
-  # API.
-  pass
-
-
-def _add_text(cls):
-  return lambda element: cls(_utf8(element.text))
-
-
 def _convert_attrs(attrs):
   # TODO(jdtang): Ideally attributes would pass along their positions as well,
   # but I can't extend the built in str objects with new attributes.  Maybe work
@@ -58,66 +47,49 @@ def _convert_attrs(attrs):
   return [(_utf8(attr.name), _utf8(attr.value)) for attr in attrs]
 
 
-class _Converter(object):
-  def __init__(self, text, **kwargs):
-    # We need to record the addresses of GumboNodes as we add them and correlate
-    # them with the BeautifulSoup objects that they become.  This lets us
-    # correctly wire up the next/previous pointers so that they point to
-    # BeautifulSoup objects instead of ctypes ones.
-    self._node_map = {}
-    self._HANDLERS = [
-        _add_document,
-        self._add_element,
-        _add_text(BeautifulSoup.NavigableString),
-        _add_text(BeautifulSoup.CData),
-        _add_text(BeautifulSoup.Comment),
-        _add_text(BeautifulSoup.NavigableString),
-        ]
-    self.soup = BeautifulSoup.BeautifulSoup()
-    with gumboc.parse(text, **kwargs) as output:
-      self.soup.append(self._add_node(output.contents.root.contents))
-    
-    self._fix_next_prev_pointers(self.soup)
+def _add_document(soup, element):
+  # Currently ignored, since there's no real place for this in the BeautifulSoup
+  # API.
+  pass
 
-  def _add_element(self, element):
-    tag = BeautifulSoup.Tag(
-        self.soup, _utf8(element.tag_name), _convert_attrs(element.attributes))
-    for child in element.children:
-      tag.append(self._add_node(child))
-    _add_source_info(
-        tag, element.original_tag, element.start_pos, element.end_pos)
-    tag.original_end_tag = str(element.original_end_tag)
-    return tag
 
-  def _add_node(self, node):
-    result = self._HANDLERS[node.type.value](node.contents)
+def _add_element(soup, element):
+  # TODO(jdtang): Expose next/previous in gumbo so they can be passed along to
+  # BeautifulSoup.
+  tag = BeautifulSoup.Tag(
+      soup, _utf8(element.tag_name), _convert_attrs(element.attributes))
+  for child in element.children:
+    tag.append(_add_node(soup, child))
+  _add_source_info(
+      tag, element.original_tag, element.start_pos, element.end_pos)
+  tag.original_end_tag = str(element.original_end_tag)
+  return tag
 
-    try:
-      result.next_addr = ctypes.addressof(node.next.contents)
-    except ValueError:
-      # Null pointer.
-      result.next_addr = 0
 
-    try:
-      result.prev_addr = ctypes.addressof(node.prev.contents)
-    except ValueError:
-      # Null pointer.
-      result.prev_addr = 0
+def _add_text(cls):
+  def add_text_internal(soup, element):
+    text = cls(_utf8(element.text))
+    return text
+  return add_text_internal
 
-    self._node_map[ctypes.addressof(node.contents)] = result
-    return result
 
-  def _fix_next_prev_pointers(self, tag):
-    tag.next = self._node_map.get(tag.next_addr)
-    tag.prev = self._node_map.get(tag.prev_addr)
-    try:
-      for child in tag.children:
-        self._fix_next_prev_pointers(child)
-    except (AttributeError, TypeError):
-      # NavigableStrings
-      pass
+_HANDLERS = [
+    _add_document,
+    _add_element,
+    _add_text(BeautifulSoup.NavigableString),
+    _add_text(BeautifulSoup.CData),
+    _add_text(BeautifulSoup.Comment),
+    _add_text(BeautifulSoup.NavigableString),
+    _add_element,
+    ]
+
+
+def _add_node(soup, node):
+  return _HANDLERS[node.type.value](soup, node.contents)
 
 
 def parse(text, **kwargs):
-  converter = _Converter(text, **kwargs)
-  return converter.soup
+  with gumboc.parse(text, **kwargs) as output:
+    soup = BeautifulSoup.BeautifulSoup()
+    soup.append(_add_node(soup, output.contents.root.contents))
+    return soup

--- a/python/gumbo/soup_adapter_test.py
+++ b/python/gumbo/soup_adapter_test.py
@@ -43,6 +43,8 @@ class SoupAdapterTest(unittest.TestCase):
     self.assertEquals(head, body.previousSibling)
     self.assertEquals(2, len(body))  # <ul> + trailing whitespace
     self.assertEquals(u'ul', body.contents[0].name)
+    self.assertEquals(body, head.next)
+    self.assertEquals(head, body.previous)
 
     list_items = body.findAll('li')
     self.assertEquals(4, len(list_items))
@@ -53,6 +55,8 @@ class SoupAdapterTest(unittest.TestCase):
     a2 = body.find('a', href='two.html')
     self.assertEquals(u'a', a2.name)
     self.assertEquals(u'Two', a2.contents[0])
+    self.assertEquals(a2, evens[0].next)
+    self.assertEquals(evens[0], a2.previous)
 
     li2 = a2.parent
     self.assertEquals(u'li', li2.name)

--- a/src/gumbo.h
+++ b/src/gumbo.h
@@ -523,19 +523,6 @@ struct GumboInternalNode {
   /** Pointer back to parent node.  Not owned. */
   GumboNode* parent;
 
-  /**
-   * Pointer to next node in document order.  This is the next node by start tag
-   * position in the document, or by position of the tag that forces the parser
-   * to insert it for parser-inserted nodes.  It's necessary to maintain API
-   * compatibility with some other libraries, eg. BeautifulSoup.  Not owned.
-   */
-  GumboNode* next;
-
-  /**
-   * Pointer to previous node in document order.
-   */
-  GumboNode* prev;
-
   /** The index within the parent's children vector of this node. */
   size_t index_within_parent;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -1243,11 +1243,6 @@ GumboNode* clone_node(
   *new_node = *node;
   new_node->parent = NULL;
   new_node->index_within_parent = -1;
-  // Fix up the next/prev pointers so that it appears directly after the node it
-  // was cloned from.
-  new_node->next = node->next;
-  new_node->prev = node;
-  node->next = new_node;
   // Clear the GUMBO_INSERTION_IMPLICIT_END_TAG flag, as the cloned node may
   // have a separate end tag.
   new_node->parse_flags &= ~GUMBO_INSERTION_IMPLICIT_END_TAG;

--- a/src/parser.c
+++ b/src/parser.c
@@ -53,7 +53,7 @@ typedef char gumbo_tagset[GUMBO_TAG_LAST];
 static bool node_html_tag_is(const GumboNode*, GumboTag);
 static GumboInsertionMode get_current_template_insertion_mode(const GumboParser*);
 static bool handle_in_template(GumboParser*, GumboToken*);
-static GumboNode* destroy_node(GumboParser*, GumboNode*);
+static void destroy_node(GumboParser*, GumboNode*);
 
 
 static void* malloc_wrapper(void* unused, size_t size) {
@@ -411,10 +411,6 @@ typedef struct GumboInternalParserState {
   // The current token.
   GumboToken* _current_token;
 
-  // The current (most recently inserted) node.  This is used to link together
-  // nodes in document order.
-  GumboNode* _current_node;
-
   // The way that the spec is written, the </body> and </html> tags are *always*
   // implicit, because encountering one of those tokens merely switches the
   // insertion mode out of "in body".  So we have individual state flags for
@@ -467,17 +463,7 @@ static void set_frameset_not_ok(GumboParser* parser) {
 }
 
 static GumboNode* create_node(GumboParser* parser, GumboNodeType type) {
-  GumboParserState* state = parser->_parser_state;
   GumboNode* node = gumbo_parser_allocate(parser, sizeof(GumboNode));
-
-  node->next = NULL;
-  node->prev = state->_current_node;
-  if (state->_current_node != NULL) {
-    // May be null for the initial document node.
-    state->_current_node->next = node;
-  }
-  state->_current_node = node;
-
   node->parent = NULL;
   node->index_within_parent = -1;
   node->type = type;
@@ -526,7 +512,6 @@ static void parser_state_init(GumboParser* parser) {
   parser_state->_form_element = NULL;
   parser_state->_fragment_ctx = NULL;
   parser_state->_current_token = NULL;
-  parser_state->_current_node = NULL;
   parser_state->_closed_body_tag = false;
   parser_state->_closed_html_tag = false;
   parser->_parser_state = parser_state;
@@ -542,7 +527,6 @@ static void parser_state_destroy(GumboParser* parser) {
   gumbo_vector_destroy(parser, &state->_template_insertion_modes);
   gumbo_string_buffer_destroy(parser, &state->_text_node._buffer);
   gumbo_parser_deallocate(parser, state);
-  parser->_parser_state = NULL;
 }
 
 static GumboNode* get_document_node(GumboParser* parser) {
@@ -2352,11 +2336,14 @@ static bool handle_after_head(GumboParser* parser, GumboToken* token) {
   }
 }
 
-static GumboNode* destroy_node(GumboParser* parser, GumboNode* node) {
+static void destroy_node(GumboParser* parser, GumboNode* node) {
   switch (node->type) {
     case GUMBO_NODE_DOCUMENT:
       {
         GumboDocument* doc = &node->v.document;
+        for (int i = 0; i < doc->children.length; ++i) {
+          destroy_node(parser, doc->children.data[i]);
+        }
         gumbo_parser_deallocate(parser, (void*) doc->children.data);
         gumbo_parser_deallocate(parser, (void*) doc->name);
         gumbo_parser_deallocate(parser, (void*) doc->public_identifier);
@@ -2369,6 +2356,9 @@ static GumboNode* destroy_node(GumboParser* parser, GumboNode* node) {
         gumbo_destroy_attribute(parser, node->v.element.attributes.data[i]);
       }
       gumbo_parser_deallocate(parser, node->v.element.attributes.data);
+      for (int i = 0; i < node->v.element.children.length; ++i) {
+        destroy_node(parser, node->v.element.children.data[i]);
+      }
       gumbo_parser_deallocate(parser, node->v.element.children.data);
       break;
     case GUMBO_NODE_TEXT:
@@ -2378,21 +2368,7 @@ static GumboNode* destroy_node(GumboParser* parser, GumboNode* node) {
       gumbo_parser_deallocate(parser, (void*) node->v.text.text);
       break;
   }
-  // Remove from the next/prev linked list.
-  GumboNode* prev = node->prev;
-  GumboNode* next = node->next;
-  if (prev != NULL) {
-    prev->next = next;
-  }
-  if (next != NULL) {
-    next->prev = prev;
-  }
-  if (parser->_parser_state && parser->_parser_state->_current_node == node) {
-    parser->_parser_state->_current_node = prev;
-  }
-
   gumbo_parser_deallocate(parser, node);
-  return next;
 }
 
 // http://www.whatwg.org/specs/web-apps/current-work/complete/tokenization.html#parsing-main-inbody
@@ -4068,14 +4044,9 @@ GumboOutput* gumbo_parse_fragment(
     const GumboTag fragment_ctx, const GumboNamespaceEnum fragment_namespace) {
   GumboParser parser;
   parser._options = options;
-  parser_state_init(&parser);
-  // Must come after parser_state_init, since creating the document node must
-  // reference parser_state->_current_node.
   output_init(&parser);
-  // And this must come after output_init, because initializing the tokenizer
-  // reads the first character and that may cause a UTF-8 decode error
-  // (inserting into output->errors) if that's invalid.
   gumbo_tokenizer_state_init(&parser, buffer, length);
+  parser_state_init(&parser);
 
   if (fragment_ctx != GUMBO_TAG_LAST) {
     fragment_parser_init(&parser, fragment_ctx, fragment_namespace);
@@ -4167,16 +4138,20 @@ GumboOutput* gumbo_parse_fragment(
   return parser._output;
 }
 
+void gumbo_destroy_node(GumboOptions* options, GumboNode* node) {
+  // Need a dummy GumboParser because the allocator comes along with the
+  // options object.
+  GumboParser parser;
+  parser._options = options;
+  destroy_node(&parser, node);
+}
+
 void gumbo_destroy_output(const GumboOptions* options, GumboOutput* output) {
   // Need a dummy GumboParser because the allocator comes along with the
   // options object.
   GumboParser parser;
-  parser._parser_state = NULL;
   parser._options = options;
-  GumboNode* current = output->document;
-  while (current) {
-    current = destroy_node(&parser, current);
-  }
+  destroy_node(&parser, output->document);
   for (int i = 0; i < output->errors.length; ++i) {
     gumbo_error_destroy(&parser, output->errors.data[i]);
   }


### PR DESCRIPTION
This removes the next & previous fields from the C API.  These complicated memory management & node insertion in the parser, they took up memory in the tree, and they were confusing to many users who wondered what was the difference between following the next/prev linked list vs. traversing the tree in-order.

The BeautifulSoup3 adaptor (which was the biggest consumer of these, needing it to implement findAll/find) now computes them inside the adaptor by traversing the parse tree, sorting it in order of starting offset, and building up a doubly-linked list by traversing that generator.  Client code which needs it can use a similar technique.

Memory usage before, taken via [GumboStats](https://github.com/nostrademons/GumboStats) run on a segment of the CommonCrawl corpus:

Num document = 38632
parse_time: mean=6423.22, median=4577.00, 95th%=17177.00, max=140327.00
traversal_time: mean=107006.08, median=67000.00, 95th%=324000.00, max=2610000.00
allocations: mean=25057.42, median=18888.00, 95th%=64451.50, max=494156.00
bytes_allocated: mean=903434.03, median=674463.00, 95th%=2313417.90, max=16482945.00
high_water_mark: mean=491042.14, median=284828.00, 95th%=985726.60, max=4294967292.00
num_nodes: mean=2158.76, median=1625.00, 95th%=5583.45, max=58932.00

After:
Num document = 38632
parse_time: mean=6318.93, median=4524.00, 95th%=16951.80, max=110751.00
traversal_time: mean=99853.80, median=64000.00, 95th%=300000.00, max=2694000.00
allocations: mean=25057.42, median=18888.00, 95th%=64451.50, max=494156.00
bytes_allocated: mean=868885.79, median=648020.00, 95th%=2224059.50, max=15605721.00
high_water_mark: mean=456827.33, median=258359.00, 95th%=897593.25, max=4294967292.00
num_nodes: mean=2158.76, median=1625.00, 95th%=5583.45, max=58932.00

Savings of about 5%.  Interestingly, there's an improvement in traversal time as well, probably due to cache effects.