### PR TITLE
Test for both glibtoolize and libtoolize on Mac; the downloaded version ...

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -15,7 +15,14 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 if test -z "$LIBTOOLIZE" -a "`uname`" = "Darwin"; then
-  LIBTOOLIZE=glibtoolize
+	if command -v "glibtoolize" >/dev/null; then
+		LIBTOOLIZE=glibtoolize
+	elif command -v "libtoolize" >/dev/null; then
+		LIBTOOLIZE=libtoolize
+	else
+		echo "autogen.sh: line $LINENO: command glibtoolize or libtoolize not found"
+		exit 1
+	fi
 fi
 
 set -ex


### PR DESCRIPTION
Fixes #315.  The patch is similar to libuv's autogen.sh, test for both glibtoolize and libtoolize and set the command name appropriately.