### PR TITLE
Create AppVeyor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gumbo - A pure-C HTML5 parser.
 ============
 
-[![Build Status](https://travis-ci.org/google/gumbo-parser.svg?branch=master)](https://travis-ci.org/google/gumbo-parser)
+[![Build Status](https://travis-ci.org/google/gumbo-parser.svg?branch=master)](https://travis-ci.org/google/gumbo-parser) [![Build status](https://ci.appveyor.com/api/projects/status/mk25v8d4t2u4253x?svg=true)](https://ci.appveyor.com/project/lowjoel/gumbo-parser)
 
 Gumbo is an implementation of the [HTML5 parsing algorithm][] implemented
 as a pure C99 library with no outside dependencies.  It's designed to serve

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+version: 1.0.{build}
+build:
+  project: visualc/gumbo.vcxproj
+  verbosity: minimal


### PR DESCRIPTION
Closes #320.

This would require the project owners to set up [AppVeyor](https://ci.appveyor.com) and it should automatically pick up the `appveyor.yml` config.

Remember to fix the path to the README.md badge, however. It's currently pointing to mine (as a demonstration).