### PR TITLE
Revert "Utf8 speedup"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ CLASSIFIERS = [
 ]
 
 setup(name='gumbo',
-      version='0.9.4',
+      version='0.9.2',
       description='Python bindings for Gumbo HTML parser',
       long_description=README,
       url='http://github.com/google/gumbo-parser',

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -188,26 +188,11 @@ static void update_position(Utf8Iterator* iter) {
   }
 }
 
-// Use a table for the first byte of utf8_is_invalid_code_point, for
-// performance.
-static const uint8_t kInvalidSingleByte[] = {
-  //0x1..........0x8   0xB   0xE................................0x1F
-  0,1,1,1,1,1,1,1, 1,0,0,1,0,0,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 
-  //                                                            0x7F
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,1, 
-  // 0x80.......................................................0x9F
-  1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 
-  0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 
-};
-
 // Returns true if this Unicode code point is in the list of characters
 // forbidden by the HTML5 spec, such as undefined control chars.
 bool utf8_is_invalid_code_point(int c) {
-  return (c < 0xFF && kInvalidSingleByte[c]) || (c >= 0xFDD0 && c <= 0xFDEF) ||
+  return (c >= 0x1 && c <= 0x8) || c == 0xB || (c >= 0xE && c <= 0x1F) ||
+      (c >= 0x7F && c <= 0x9F) || (c >= 0xFDD0 && c <= 0xFDEF) ||
       ((c & 0xFFFF) == 0xFFFE) || ((c & 0xFFFF) == 0xFFFF);
 }
 


### PR DESCRIPTION
Reverts google/gumbo-parser#310

This caused a security regression, reported in #328.  The speedup is too marginal to be worth it.