### PR TITLE
parser: Do not pop the stack if it doesn't contain `select` in scope

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3468,7 +3468,9 @@ static bool handle_in_select(GumboParser* parser, GumboToken* token) {
   } else if (tag_is(token, kStartTag, GUMBO_TAG_SELECT)) {
     parser_add_parse_error(parser, token);
     ignore_token(parser);
-    close_current_select(parser);
+    if (has_an_element_in_select_scope(parser, GUMBO_TAG_SELECT)) {
+      close_current_select(parser);
+    }
     return false;
   } else if (tag_in(token, kStartTag, (gumbo_tagset) { TAG(INPUT), TAG(KEYGEN), TAG(TEXTAREA) })) {
     parser_add_parse_error(parser, token);


### PR DESCRIPTION
Fixes https://github.com/google/gumbo-parser/issues/331

This change matches the spec properly now: 

> If the stack of open elements does not have a select element in select scope, ignore the token. (fragment case)
> Otherwise:
> Pop elements from the stack of open elements until a select element has been popped from the stack.

Note that we call `ignore_token` on both cases because the token is always effectively ignored by the parser (even through the spec text doesn't explicitly say it). Also, not calling `ignore_token` would cause it to leak.