### PR TITLE
Fix error mesage use of return value form vnsprintf

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -59,7 +59,7 @@ static int print_message(
   }
 #endif
 
-  if (bytes_written > remaining_capacity) {
+  if (bytes_written >= remaining_capacity) {
     gumbo_string_buffer_reserve(
         parser, output->capacity + bytes_written, output);
     remaining_capacity = output->capacity - output->length;


### PR DESCRIPTION
Here is the pull request to fix Issue # 357