### PR TITLE
Fix tag name filtering that could result in XSS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,7 @@ gumbo_test_SOURCES = \
 				tests/string_buffer.cc \
 				tests/string_piece.cc \
 				tests/tokenizer.cc \
+				tests/tag.cc \
 				tests/test_utils.cc \
 				tests/utf8.cc \
 				tests/vector.cc

--- a/gumbo_parser.gyp
+++ b/gumbo_parser.gyp
@@ -67,6 +67,7 @@
         'tests/string_piece.cc',
         'tests/test_utils.cc',
         'tests/test_utils.h',
+        'tests/tag.cc',
         'tests/tokenizer.cc',
         'tests/utf8.cc',
         'tests/vector.cc',

--- a/src/tag.c
+++ b/src/tag.c
@@ -55,9 +55,10 @@ void gumbo_tag_from_original_text(GumboStringPiece* text) {
     text->data += 1;  // Move past <
     text->length -= 2;
     // strnchr is apparently not a standard C library function, so I loop
-    // explicitly looking for whitespace or other illegal tag characters.
+    // explicitly looking for whitespace or other illegal tag characters - as
+    // accepted by the Tag Name State
     for (const char* c = text->data; c != text->data + text->length; ++c) {
-      if (isspace(*c) || *c == '/') {
+      if (*c == '\t' || *c == '\n' || *c == '\f' || *c == ' ' || *c == '/') {
         text->length = c - text->data;
         break;
       }

--- a/tests/tag.cc
+++ b/tests/tag.cc
@@ -1,0 +1,60 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: jdtang@google.com (Jonathan Tang)
+
+#include "gumbo.h"
+
+#include <string.h>
+
+#include "gtest/gtest.h"
+#include "error.h"
+#include "test_utils.h"
+
+namespace {
+
+// Tests for tag.c
+class TagTest : public GumboTest {
+};
+
+TEST_F(TagTest, AllowedWhitespacesInTagName) {
+  GumboStringPiece sp;
+  sp.data = "<script\v\r>";
+  const size_t len = strlen(sp.data);
+  sp.length = len;
+
+  gumbo_tag_from_original_text(&sp);
+  EXPECT_EQ(len - 2, sp.length);
+  EXPECT_EQ(memcmp(sp.data, "script\v\r", len - 2), 0);
+}
+
+TEST_F(TagTest, IllegalCharsInTagName) {
+  const char illegal_chars[] = { '\t', '\n', '\f', ' ', '/' };
+  char pattern[] = "<scr?ipt>"; // ? as a placeholder
+
+  for (size_t i = 0; i < sizeof(illegal_chars) / sizeof(char); ++i) {
+    GumboStringPiece sp;
+    sp.data = pattern;
+    const size_t len = strlen(sp.data);
+    sp.length = len;
+
+    pattern[4] = illegal_chars[i];
+
+    gumbo_tag_from_original_text(&sp);
+    EXPECT_EQ(3, sp.length);
+    EXPECT_EQ(memcmp(sp.data, "scr", 3), 0);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
`gumbo_tag_from_original_text` currently uses `isspace` to detect illegal whitespaces in tag names.

`isspace` will match on `\v` and `\r`, which are not illegal according to the spec (https://html.spec.whatwg.org/multipage/syntax.html#tag-name-state).

This can result in an XSS that will not be possible in a standard-compliant parser: In the current implementation, `gumbo_tag_from_original_text` will return `<script>` on the unknown element `<script\v>` (or `<script\rnotreallyscript>`).

Serializers relaying on `gumbo_tag_from_original_text` (such as `prettyprint`) will transform non-executable `<script\v>` tags to executable `<script>` tags.

This diff applies the whitelist in the spec to `gumbo_tag_from_original_text` and adds unit-tests for this scenario.