### PR TITLE
performance: declare gumbo_debug as inline function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ os:
   - osx
 
 install:
-  - wget 'https://googletest.googlecode.com/files/gtest-1.7.0.zip'
-  - unzip gtest-1.7.0.zip
-  - ln -s gtest-1.7.0 gtest
+  - git clone --branch release-1.7.0 --depth 1 https://github.com/google/googletest.git gtest
+  - touch gtest/build-aux/config.h.in
+  - cd gtest && ../autogen.sh && cd ..
   - sudo pip install BeautifulSoup
   - sudo pip install html5lib==0.95
 

--- a/src/util.c
+++ b/src/util.c
@@ -44,15 +44,3 @@ char* gumbo_copy_stringz(GumboParser* parser, const char* str) {
   strcpy(buffer, str);
   return buffer;
 }
-
-// Debug function to trace operation of the parser.  Pass --copts=-DGUMBO_DEBUG
-// to use.
-void gumbo_debug(const char* format, ...) {
-#ifdef GUMBO_DEBUG
-  va_list args;
-  va_start(args, format);
-  vprintf(format, args);
-  va_end(args);
-  fflush(stdout);
-#endif
-}

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,17 @@ void gumbo_parser_deallocate(struct GumboInternalParser* parser, void* ptr);
 
 // Debug wrapper for printf, to make it easier to turn off debugging info when
 // required.
-void gumbo_debug(const char* format, ...);
+// Debug function to trace operation of the parser.  Pass --copts=-DGUMBO_DEBUG
+// to use.
+void inline gumbo_debug(const char* format, ...) {
+#ifdef GUMBO_DEBUG
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+  fflush(stdout);
+#endif
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Now using the perf profiler on user space to benchmark gumbo_parser at Centos6.5 as the following:

```bash
perf record -g --all-user benchmarks/benchmark
```

It shows the [gumbo_debug](https://github.com/google/gumbo-parser/blob/master/src/util.c#50) function will occupy approximate %1.10 On-CPU at `retq` instruction.
![screen shot 2017-04-20 at 15 12 13](https://cloud.githubusercontent.com/assets/3370345/25219765/08bb1f2c-25e2-11e7-84d1-4b980d326cfe.png)
and
![screen shot 2017-04-20 at 16 06 19](https://cloud.githubusercontent.com/assets/3370345/25220105/55be22a0-25e3-11e7-8741-b80884bfdcf4.png)


To eliminate the overhead of function call even if it's compiled on release mode, [gumbo_debug](https://github.com/google/gumbo-parser/blob/master/src/util.c#50) should be declared  as inline function.

Also apply @stevecheckoway's PR #378 to pass CI.

@nostrademons  Can you have a look at it ? Many thanks !