### PR TITLE
Handle entity overflow by treating as NUL

### DIFF
--- a/src/char_ref.c
+++ b/src/char_ref.c
@@ -138,8 +138,15 @@ static bool consume_numeric_ref(
 
   int codepoint = 0;
   bool status = true;
+  bool poisoned = false;
   do {
-    codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
+    if (!poisoned) {
+      codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
+      if (codepoint < 0) {
+        codepoint = 0;
+        poisoned = true;
+      }
+    }
     utf8iterator_next(input);
     digit = parse_digit(utf8iterator_current(input), is_hex);
   } while (digit != -1);

--- a/src/char_ref.c
+++ b/src/char_ref.c
@@ -142,7 +142,7 @@ static bool consume_numeric_ref(
   do {
     if (!poisoned) {
       codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
-      if (codepoint < 0) {
+      if (codepoint > 0x10FFFF) {
         codepoint = 0;
         poisoned = true;
       }

--- a/src/char_ref.rl
+++ b/src/char_ref.rl
@@ -168,7 +168,7 @@ static bool consume_numeric_ref(
   do {
     if (!poisoned) {
       codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
-      if (codepoint < 0) {
+      if (codepoint > 0x10FFFF) {
         codepoint = 0;
         poisoned = true;
       }

--- a/src/char_ref.rl
+++ b/src/char_ref.rl
@@ -164,8 +164,15 @@ static bool consume_numeric_ref(
 
   int codepoint = 0;
   bool status = true;
+  bool poisoned = false;
   do {
-    codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
+    if (!poisoned) {
+      codepoint = (codepoint * (is_hex ? 16 : 10)) + digit;
+      if (codepoint < 0) {
+        codepoint = 0;
+        poisoned = true;
+      }
+    }
     utf8iterator_next(input);
     digit = parse_digit(utf8iterator_current(input), is_hex);
   } while (digit != -1);

--- a/tests/char_ref.cc
+++ b/tests/char_ref.cc
@@ -107,6 +107,14 @@ TEST_F(CharRefTest, NumericUtfInvalid) {
   EXPECT_EQ(kGumboNoChar, output_.second);
 }
 
+TEST_F(CharRefTest, NumericHuge) {
+  errors_are_expected_ = true;
+  EXPECT_FALSE(ConsumeCharRef("&#x80000007x"));
+  EXPECT_GE(output_.first, 0);
+  EXPECT_EQ(kGumboNoChar, output_.second);
+  EXPECT_EQ('x', utf8iterator_current(&iter_));
+}
+
 TEST_F(CharRefTest, NamedReplacement) {
   EXPECT_TRUE(ConsumeCharRef("&lt;"));
   EXPECT_EQ('<', output_.first);

--- a/tests/char_ref.cc
+++ b/tests/char_ref.cc
@@ -110,7 +110,7 @@ TEST_F(CharRefTest, NumericUtfInvalid) {
 TEST_F(CharRefTest, NumericHuge) {
   errors_are_expected_ = true;
   EXPECT_FALSE(ConsumeCharRef("&#x80000007x"));
-  EXPECT_GE(output_.first, 0);
+  EXPECT_EQ(0xFFFD, output_.first);
   EXPECT_EQ(kGumboNoChar, output_.second);
   EXPECT_EQ('x', utf8iterator_current(&iter_));
 }


### PR DESCRIPTION
Huge numeric entities cause an issue with Gumbo; the `int` containing the codepoint overflows. The "negative" codepoints (such as `&#80000007;`) have only their low byte written directly to the output, producing non-UTF-8 output.

If we detect overflow, we "poison" the reference, continuing to read the rest of it in but treating it like a NUL, producing a replacement character.