### PR TITLE
sink and hoist loads and stores from a hot loop

### DIFF
--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -78,10 +78,13 @@ void gumbo_string_buffer_append_codepoint(
     prefix = 0xf0;
   }
   maybe_resize_string_buffer(parser, num_bytes + 1, output);
-  output->data[output->length++] = prefix | (c >> (num_bytes * 6));
+  int length = output->length;
+  char* data = output->data;
+  data[length++] = prefix | (c >> (num_bytes * 6));
   for (int i = num_bytes - 1; i >= 0; --i) {
-    output->data[output->length++] = 0x80 | (0x3f & (c >> (i * 6)));
+    data[length++] = 0x80 | (0x3f & (c >> (i * 6)));
   }
+  output->length = length;
 }
 
 void gumbo_string_buffer_append_string(struct GumboInternalParser* parser,


### PR DESCRIPTION
Both LLVM and GCC compilers are unable to prove that output->data does not alias with output->length, so they will not be able to remove the redundant loads and stores from this loop.