### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ them as the super user.
 Debian installs usually don't have `sudo` installed (Ubuntu however does.)
 Switch users first with `su -`, then run `apt-get`.
 
+Building gumbo - Using vcpkg
+
+You can download and install Gumbo using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install gumbo
+
+The Gumbo port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Basic Usage
 ===========
 


### PR DESCRIPTION
Gumbo is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for Gumbo and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build Gumbo, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/gumbo/portfile.cmake). We try to keep the library maintained as close as possible to the original library.