### PR TITLE
docs: fix simple typo, preceeding -> preceding

### DIFF
--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -409,7 +409,7 @@ static void reset_token_start_point(GumboTokenizerState* tokenizer) {
 
 // Sets the tag buffer original text and start point to the current iterator
 // position.  This is necessary because attribute names & values may have
-// whitespace preceeding them, and so we can't assume that the actual token
+// whitespace preceding them, and so we can't assume that the actual token
 // starting point was the end of the last tag buffer usage.
 static void reset_tag_buffer_start_point(GumboParser* parser) {
   GumboTokenizerState* tokenizer = parser->_tokenizer_state;


### PR DESCRIPTION
There is a small typo in src/tokenizer.c.

Should read `preceding` rather than `preceeding`.

